### PR TITLE
Removed unnecessary parameter

### DIFF
--- a/alpha_vantage/techindicators.py
+++ b/alpha_vantage/techindicators.py
@@ -143,7 +143,7 @@ class TechIndicators(av):
 
     @av._output_format
     @av._call_api_on_func
-    def get_mama(self, symbol, interval='daily', time_period=20, series_type='close',
+    def get_mama(self, symbol, interval='daily', series_type='close',
                  fastlimit=None, slowlimit=None):
         """ Return MESA adaptative moving average time series in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -153,7 +153,6 @@ class TechIndicators(av):
             interval:  time interval between two conscutive values,
                 supported values are '1min', '5min', '15min', '30min', '60min', 'daily',
                 'weekly', 'monthly' (default 'daily')
-            time_period:  How many data points to average (default 20)
             series_type:  The desired price type in the time series. Four types
                 are supported: 'close', 'open', 'high', 'low' (default 'close')
             fastlimit:  Positive floats for the fast limit are accepted


### PR DESCRIPTION
The MAMA indicator does not have time_period as a parameter: 

https://www.alphavantage.co/documentation/#mama