### PR TITLE
Remove unused json/simplejson packages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ python:
     - '3.6'
 
 install:
-    - pip install simplejson
     - pip install pandas==0.19.2
     - pip install requests
     - pip install requests-mock

--- a/alpha_vantage/alphavantage.py
+++ b/alpha_vantage/alphavantage.py
@@ -1,6 +1,5 @@
 import requests
 import os
-import sys
 from functools import wraps
 import inspect
 # Pandas became an optional dependency, but we still want to track it
@@ -10,12 +9,6 @@ try:
 except ImportError:
     _PANDAS_FOUND = False
 import csv
-
-# Avoid compability issues
-if sys.version_info.major == 3 and sys.version_info.minor == 6:
-    from json import loads
-else:
-    from simplejson import loads
 
 
 class AlphaVantage(object):

--- a/alpha_vantage/alphavantage.py
+++ b/alpha_vantage/alphavantage.py
@@ -34,7 +34,9 @@ class AlphaVantage(object):
             indexing_type: Either 'date' to use the default date string given
             by the alpha vantage api call or 'integer' if you just want an
             integer indexing on your dataframe. Only valid, when the
-            output_format is 'pandas'.
+            output_format is 'pandas'
+            proxy: Dictionary mapping protocol or protocol and hostname to 
+            the URL of the proxy.
         """
         if key is None:
             key = os.getenv('ALPHAVANTAGE_API_KEY')
@@ -215,6 +217,12 @@ class AlphaVantage(object):
         return _format_wrapper
 
     def set_proxy(self, proxy=None):
+        """ Set a new proxy configuration
+
+        Keyword Arguments:
+            proxy: Dictionary mapping protocol or protocol and hostname to 
+            the URL of the proxy.
+        """
         self.proxy = proxy or {}
 
     def map_to_matype(self, matype):

--- a/alpha_vantage/alphavantage.py
+++ b/alpha_vantage/alphavantage.py
@@ -22,7 +22,7 @@ class AlphaVantage(object):
         "https://www.alphavantage.co/digital_currency_list/"
 
     def __init__(self, key=None, retries=5, output_format='json',
-                 treat_info_as_error=True, indexing_type='date', proxy={}):
+                 treat_info_as_error=True, indexing_type='date', proxy=None):
         """ Initialize the class
 
         Keyword Arguments:
@@ -57,7 +57,7 @@ class AlphaVantage(object):
         # variable will be overriden by those functions not needing it.
         self._append_type = True
         self.indexing_type = indexing_type
-        self.proxy = proxy
+        self.proxy = proxy or {}
 
     def _retry(func):
         """ Decorator for retrying api calls (in case of errors from the api
@@ -214,8 +214,8 @@ class AlphaVantage(object):
                     self.output_format))
         return _format_wrapper
 
-    def set_proxy(self, proxy={}):
-        self.proxy = proxy
+    def set_proxy(self, proxy=None):
+        self.proxy = proxy or {}
 
     def map_to_matype(self, matype):
         """ Convert to the alpha vantage math type integer. It returns an

--- a/setup.py
+++ b/setup.py
@@ -29,8 +29,7 @@ setup(
     ],
     url='https://github.com/RomelTorres/alpha_vantage',
     install_requires=[
-        'requests',
-        'simplejson'
+        'requests'
     ],
     test_requires=[
         'nose',


### PR DESCRIPTION
Since the move to use `request` package instead of `urllib` package,
There is no need for an external JSON loads function.
In addition, The `import sys` statement has been removed from the same reason.

**Relevant commits:**
[Fix url forming issue](https://github.com/RomelTorres/alpha_vantage/commit/ff0c4626f611f0ace70fcdad5ab22a2c19fb7285#diff-a92c4069ffe649b7e28a0291fda794da)
[Change urllib for requests](https://github.com/RomelTorres/alpha_vantage/commit/1280ac545923dcefde7656408b96f22b97a91530#diff-a92c4069ffe649b7e28a0291fda794da)
