### PR TITLE
Casting date index to datetime

### DIFF
--- a/alpha_vantage/alphavantage.py
+++ b/alpha_vantage/alphavantage.py
@@ -204,9 +204,8 @@ class AlphaVantage(object):
                                                                  orient='index',
                                                                  dtype=float)
                     data_pandas.index.name = 'date'
-                    data_pandas = data_pandas.reset_index()
-                    data_pandas['date'] = pandas.to_datetime(data_pandas['date'])
-                    data_pandas = data_pandas.set_index('date')
+
+                    data_pandas.set_index(pandas.to_datetime(data_pandas.index), inplace=True)
 
                     if 'integer' in self.indexing_type:
                         # Set Date as an actual column so a new numerical index

--- a/alpha_vantage/alphavantage.py
+++ b/alpha_vantage/alphavantage.py
@@ -204,6 +204,10 @@ class AlphaVantage(object):
                                                                  orient='index',
                                                                  dtype=float)
                     data_pandas.index.name = 'date'
+                    data_pandas = data_pandas.reset_index()
+                    data_pandas['date'] = pandas.to_datetime(data_pandas['date'])
+                    data_pandas = data_pandas.set_index('date')
+
                     if 'integer' in self.indexing_type:
                         # Set Date as an actual column so a new numerical index
                         # will be created, but only when specified by the user.

--- a/test_alpha_vantage/test_alphavantage.py
+++ b/test_alpha_vantage/test_alphavantage.py
@@ -4,7 +4,7 @@ from ..alpha_vantage.techindicators import TechIndicators
 from ..alpha_vantage.sectorperformance import SectorPerformances
 from ..alpha_vantage.cryptocurrencies import CryptoCurrencies
 from ..alpha_vantage.foreignexchange import ForeignExchange
-from pandas import DataFrame as df
+from pandas import DataFrame as df, Timestamp
 import unittest
 import sys
 from os import path
@@ -96,10 +96,7 @@ class TestAlphaVantage(unittest.TestCase):
             mock_request.get(url, text=f.read())
             data, _ = ts.get_intraday(
                 "MSFT", interval='1min', outputsize='full')
-            if sys.version_info[0] == 3:
-                assert isinstance(data.index[0], str)
-            else:
-                assert isinstance(data.index[0], basestring)
+            assert isinstance(data.index[0], Timestamp)
 
     @requests_mock.Mocker()
     def test_time_series_intraday_date_integer(self, mock_request):


### PR DESCRIPTION
I have noticed that using the DateFrame by default is not casting the index to datetime so using the next code as a sample
```python
from alpha_vantage.cryptocurrencies import CryptoCurrencies

crypto = CryptoCurrencies(key=ALPHAVANTAGE_API_KEY, output_format='pandas')
data, meta_data = crypto.get_digital_currency_intraday('BTC', 'EUR')
data['1a. price (EUR)'].plot()
plt.title(f'{meta_data["1. Information"]} {meta_data["3. Digital Currency Name"]}')
plt.show()
```
You would get this image:
![image](https://user-images.githubusercontent.com/576885/44493986-5fdf1600-a66a-11e8-8182-137e89cbf4a2.png)

With this pull request the same code will create this other image:
![image](https://user-images.githubusercontent.com/576885/44494053-a2085780-a66a-11e8-966c-2740683e59fc.png)

Where the X axis is populated with the dates correctly

