### PR TITLE
Remove deprecated api from Alpha Vantage

### DIFF
--- a/alpha_vantage/cryptocurrencies.py
+++ b/alpha_vantage/cryptocurrencies.py
@@ -6,24 +6,6 @@ class CryptoCurrencies(av):
     """
     @av._output_format
     @av._call_api_on_func
-    def get_digital_currency_intraday(self, symbol, market):
-        """ Returns the intraday (with 5-minute intervals) time series for a
-        digital currency (e.g., BTC) traded on a specific market
-        (e.g., CNY/Chinese Yuan), updated realtime. Prices and volumes are
-        quoted in both the market-specific currency and USD.
-
-        Keyword Arguments:
-            symbol: The digital/crypto currency of your choice. It can be any
-            of the currencies in the digital currency list. For example:
-            symbol=BTC.
-            market: The exchange market of your choice. It can be any of the
-            market in the market list. For example: market=CNY.
-        """
-        _FUNCTION_KEY = 'DIGITAL_CURRENCY_INTRADAY'
-        return _FUNCTION_KEY, 'Time Series (Digital Currency Intraday)', 'Meta Data'
-
-    @av._output_format
-    @av._call_api_on_func
     def get_digital_currency_daily(self, symbol, market):
         """ Returns  the daily historical time series for a digital currency
         (e.g., BTC) traded on a specific market (e.g., CNY/Chinese Yuan),

--- a/test_alpha_vantage/test_alphavantage.py
+++ b/test_alpha_vantage/test_alphavantage.py
@@ -186,35 +186,6 @@ class TestAlphaVantage(unittest.TestCase):
                 data, dict, 'Result Data must be a dictionary')
 
     @requests_mock.Mocker()
-    def test_crypto_currencies(self, mock_request):
-        """ Test that api call returns a json file as requested
-        """
-        cc = CryptoCurrencies(key=TestAlphaVantage._API_KEY_TEST)
-        url = "http://www.alphavantage.co/query?function=DIGITAL_CURRENCY_INTRADAY&symbol=BTC&market=CNY&apikey=test"
-        path_file = self.get_file_from_url("mock_crypto_currencies")
-        with open(path_file) as f:
-            mock_request.get(url, text=f.read())
-            data, _ = cc.get_digital_currency_intraday(
-                symbol='BTC', market='CNY')
-            self.assertIsInstance(
-                data, dict, 'Result Data must be a dictionary')
-
-    @requests_mock.Mocker()
-    def test_crypto_currencies_pandas(self, mock_request):
-        """ Test that api call returns a json file as requested
-        """
-        cc = CryptoCurrencies(
-            key=TestAlphaVantage._API_KEY_TEST, output_format='pandas')
-        url = "http://www.alphavantage.co/query?function=DIGITAL_CURRENCY_INTRADAY&symbol=BTC&market=CNY&apikey=test"
-        path_file = self.get_file_from_url("mock_crypto_currencies")
-        with open(path_file) as f:
-            mock_request.get(url, text=f.read())
-            data, _ = cc.get_digital_currency_intraday(
-                symbol='BTC', market='CNY')
-            self.assertIsInstance(
-                data, df, 'Result Data must be a pandas data frame')
-
-    @requests_mock.Mocker()
     def test_batch_quotes(self, mock_request):
         """ Test that api call returns a json file as requested
         """


### PR DESCRIPTION
Remove intraday cryptocurrencies call since it is no longer offered by the alpha vantage API