### PR TITLE
Returned pandas.DataFrame index is now a time object

### DIFF
--- a/alpha_vantage/alphavantage.py
+++ b/alpha_vantage/alphavantage.py
@@ -189,11 +189,15 @@ class AlphaVantage(object):
                         data_pandas = pandas.DataFrame.from_dict(data,
                                                                  orient='index',
                                                                  dtype=float)
-                    data_pandas.index.name = 'date'
                     if 'integer' in self.indexing_type:
                         # Set Date as an actual column so a new numerical index
                         # will be created, but only when specified by the user.
                         data_pandas.reset_index(level=0, inplace=True)
+                        data_pandas.index.name = 'index'
+                    else:
+                        data_pandas.index.name = 'date'
+                        # convert to pandas._libs.tslibs.timestamps.Timestamp
+                        data_pandas.index = pandas.to_datetime(data_pandas.index)
                     return data_pandas, meta_data
             elif 'csv' in self.output_format.lower():
                 return call_response, None

--- a/test_alpha_vantage/test_alphavantage.py
+++ b/test_alpha_vantage/test_alphavantage.py
@@ -4,7 +4,7 @@ from ..alpha_vantage.techindicators import TechIndicators
 from ..alpha_vantage.sectorperformance import SectorPerformances
 from ..alpha_vantage.cryptocurrencies import CryptoCurrencies
 from ..alpha_vantage.foreignexchange import ForeignExchange
-from pandas import DataFrame as df
+from pandas import DataFrame as df, Timestamp
 import unittest
 import sys
 from os import path
@@ -96,10 +96,13 @@ class TestAlphaVantage(unittest.TestCase):
             mock_request.get(url, text=f.read())
             data, _ = ts.get_intraday(
                 "MSFT", interval='1min', outputsize='full')
-            if sys.version_info[0] == 3:
-                assert isinstance(data.index[0], str)
+            if ts.indexing_type == 'date':
+                assert isinstance(data.index[0], Timestamp)
             else:
-                assert isinstance(data.index[0], basestring)
+                if sys.version_info[0] == 3:
+                    assert isinstance(data.index[0], str)
+                else:
+                    assert isinstance(data.index[0], basestring)
 
     @requests_mock.Mocker()
     def test_time_series_intraday_date_integer(self, mock_request):

--- a/test_alpha_vantage/test_integration_alphavantage.py
+++ b/test_alpha_vantage/test_integration_alphavantage.py
@@ -199,22 +199,6 @@ class TestAlphaVantage(unittest.TestCase):
                                       to_symbol='JPY',
                                       outputsize='full')
 
-    def test_get_digital_currency_intraday(self):
-        """Test that we get a dictionary containing json data
-        """
-        cc = CryptoCurrencies(key=TestAlphaVantage._API_KEY_TEST)
-        self._assert_result_is_format(cc.get_digital_currency_intraday,
-                                      output_format='json',
-                                      symbol='BTC',
-                                      market='CNY')
-        # Test panda as output
-        cc = CryptoCurrencies(
-            key=TestAlphaVantage._API_KEY_TEST, output_format='pandas')
-        self._assert_result_is_format(cc.get_digital_currency_intraday,
-                                      output_format='pandas',
-                                      symbol='BTC',
-                                      market='CNY')
-
     def test_get_digital_currency_weekly(self):
         """Test that we get a dictionary containing json data
         """


### PR DESCRIPTION
Now, TimeSeries(.., indexing_type='date') converts the index to
pandas._libs.tslibs.timestamps.Timestamp which makes it more useful
especially when plotting with df.plot() the tick labels appear
correctly.