### PR TITLE
Added more accurate error handling for keyerror

### DIFF
--- a/alpha_vantage/alphavantage.py
+++ b/alpha_vantage/alphavantage.py
@@ -11,7 +11,7 @@ except ImportError:
 import csv
 
 # Avoid compability issues
-if sys.version_info.major == 3 and sys.version_info.minor == 6:
+if sys.version_info.major == 3 and sys.version_info.minor >= 6:
     from json import loads
 else:
     from simplejson import loads
@@ -91,7 +91,7 @@ class AlphaVantage(object):
         # Argument Handling
         argspec = inspect.getargspec(func)
         try:
-            # Asumme most of the cases have a mixed between args and named
+            # Assume most of the cases have a mixed between args and named
             # args
             positional_count = len(argspec.args) - len(argspec.defaults)
             defaults = dict(
@@ -174,7 +174,10 @@ class AlphaVantage(object):
                 self, *args, **kwargs)
             if 'json' in self.output_format.lower() or 'pandas' \
                     in self.output_format.lower():
-                data = call_response[data_key]
+                try:
+                    data = call_response[data_key]
+                except Exception:
+                    raise Exception(call_response)
                 if meta_data_key is not None:
                     meta_data = call_response[meta_data_key]
                 else:


### PR DESCRIPTION
When a user hits the API key limit, the call_response variable will be a dictionary with 1 key with a value of "Note". So looking for Time Series (Daily) will be a confusing error, when the error is really how they've hit the API limit. Also a slight tweak on the simplejson import and typo in spelling

    176             if 'json' in self.output_format.lower() or 'pandas' \
    177                     in self.output_format.lower():
--> 178                 data = call_response[data_key]
    179                 if meta_data_key is not None:
    180                     meta_data = call_response[meta_data_key]
KeyError: 'Time Series (Daily)'