### PR TITLE
Send requests over https by default

### DIFF
--- a/alpha_vantage/alphavantage.py
+++ b/alpha_vantage/alphavantage.py
@@ -16,7 +16,7 @@ class AlphaVantage(object):
     """ Base class where the decorators and base function for the other
     classes of this python wrapper will inherit from.
     """
-    _ALPHA_VANTAGE_API_URL = "http://www.alphavantage.co/query?"
+    _ALPHA_VANTAGE_API_URL = "https://www.alphavantage.co/query?"
     _ALPHA_VANTAGE_MATH_MAP = ['SMA', 'EMA', 'WMA', 'DEMA', 'TEMA', 'TRIMA',
                                'T3', 'KAMA', 'MAMA']
     _ALPHA_VANTAGE_DIGITAL_CURRENCY_LIST = \

--- a/test_alpha_vantage/test_alphavantage.py
+++ b/test_alpha_vantage/test_alphavantage.py
@@ -59,7 +59,7 @@ class TestAlphaVantage(unittest.TestCase):
         """ Test that api call returns a json file as requested
         """
         ts = TimeSeries(key=TestAlphaVantage._API_KEY_TEST)
-        url = "http://www.alphavantage.co/query?function=TIME_SERIES_INTRADAY&symbol=MSFT&interval=1min&outputsize=full&apikey=test&datatype=json"
+        url = "https://www.alphavantage.co/query?function=TIME_SERIES_INTRADAY&symbol=MSFT&interval=1min&outputsize=full&apikey=test&datatype=json"
         path_file = self.get_file_from_url("mock_time_series")
         with open(path_file) as f:
             mock_request.get(url, text=f.read())
@@ -74,7 +74,7 @@ class TestAlphaVantage(unittest.TestCase):
         """
         ts = TimeSeries(key=TestAlphaVantage._API_KEY_TEST,
                         output_format='pandas')
-        url = "http://www.alphavantage.co/query?function=TIME_SERIES_INTRADAY&symbol=MSFT&interval=1min&outputsize=full&apikey=test&datatype=json"
+        url = "https://www.alphavantage.co/query?function=TIME_SERIES_INTRADAY&symbol=MSFT&interval=1min&outputsize=full&apikey=test&datatype=json"
         path_file = self.get_file_from_url("mock_time_series")
         with open(path_file) as f:
             mock_request.get(url, text=f.read())
@@ -90,7 +90,7 @@ class TestAlphaVantage(unittest.TestCase):
         """
         ts = TimeSeries(key=TestAlphaVantage._API_KEY_TEST,
                         output_format='pandas', indexing_type='date')
-        url = "http://www.alphavantage.co/query?function=TIME_SERIES_INTRADAY&symbol=MSFT&interval=1min&outputsize=full&apikey=test&datatype=json"
+        url = "https://www.alphavantage.co/query?function=TIME_SERIES_INTRADAY&symbol=MSFT&interval=1min&outputsize=full&apikey=test&datatype=json"
         path_file = self.get_file_from_url("mock_time_series")
         with open(path_file) as f:
             mock_request.get(url, text=f.read())
@@ -110,7 +110,7 @@ class TestAlphaVantage(unittest.TestCase):
         """
         ts = TimeSeries(key=TestAlphaVantage._API_KEY_TEST,
                         output_format='pandas', indexing_type='integer')
-        url = "http://www.alphavantage.co/query?function=TIME_SERIES_INTRADAY&symbol=MSFT&interval=1min&outputsize=full&apikey=test&datatype=json"
+        url = "https://www.alphavantage.co/query?function=TIME_SERIES_INTRADAY&symbol=MSFT&interval=1min&outputsize=full&apikey=test&datatype=json"
         path_file = self.get_file_from_url("mock_time_series")
         with open(path_file) as f:
             mock_request.get(url, text=f.read())
@@ -123,7 +123,7 @@ class TestAlphaVantage(unittest.TestCase):
         """ Test that api call returns a json file as requested
         """
         ti = TechIndicators(key=TestAlphaVantage._API_KEY_TEST)
-        url = "http://www.alphavantage.co/query?function=SMA&symbol=MSFT&interval=15min&time_period=10&series_type=close&apikey=test"
+        url = "https://www.alphavantage.co/query?function=SMA&symbol=MSFT&interval=15min&time_period=10&series_type=close&apikey=test"
         path_file = self.get_file_from_url("mock_technical_indicator")
         with open(path_file) as f:
             mock_request.get(url, text=f.read())
@@ -138,7 +138,7 @@ class TestAlphaVantage(unittest.TestCase):
         """
         ti = TechIndicators(
             key=TestAlphaVantage._API_KEY_TEST, output_format='pandas')
-        url = "http://www.alphavantage.co/query?function=SMA&symbol=MSFT&interval=15min&time_period=10&series_type=close&apikey=test"
+        url = "https://www.alphavantage.co/query?function=SMA&symbol=MSFT&interval=15min&time_period=10&series_type=close&apikey=test"
         path_file = self.get_file_from_url("mock_technical_indicator")
         with open(path_file) as f:
             mock_request.get(url, text=f.read())
@@ -152,7 +152,7 @@ class TestAlphaVantage(unittest.TestCase):
         """ Test that api call returns a json file as requested
         """
         sp = SectorPerformances(key=TestAlphaVantage._API_KEY_TEST)
-        url = "http://www.alphavantage.co/query?function=SECTOR&apikey=test"
+        url = "https://www.alphavantage.co/query?function=SECTOR&apikey=test"
         path_file = self.get_file_from_url("mock_sector")
         with open(path_file) as f:
             mock_request.get(url, text=f.read())
@@ -166,7 +166,7 @@ class TestAlphaVantage(unittest.TestCase):
         """
         sp = SectorPerformances(
             key=TestAlphaVantage._API_KEY_TEST, output_format='pandas')
-        url = "http://www.alphavantage.co/query?function=SECTOR&apikey=test"
+        url = "https://www.alphavantage.co/query?function=SECTOR&apikey=test"
         path_file = self.get_file_from_url("mock_sector")
         with open(path_file) as f:
             mock_request.get(url, text=f.read())
@@ -179,7 +179,7 @@ class TestAlphaVantage(unittest.TestCase):
         """ Test that api call returns a json file as requested
         """
         fe = ForeignExchange(key=TestAlphaVantage._API_KEY_TEST)
-        url = "http://www.alphavantage.co/query?function=CURRENCY_EXCHANGE_RATE&from_currency=BTC&to_currency=CNY&apikey=test"
+        url = "https://www.alphavantage.co/query?function=CURRENCY_EXCHANGE_RATE&from_currency=BTC&to_currency=CNY&apikey=test"
         path_file = self.get_file_from_url("mock_foreign_exchange")
         with open(path_file) as f:
             mock_request.get(url, text=f.read())
@@ -193,7 +193,7 @@ class TestAlphaVantage(unittest.TestCase):
         """ Test that api call returns a json file as requested
         """
         ts = TimeSeries(key=TestAlphaVantage._API_KEY_TEST)
-        url = "http://www.alphavantage.co/query?function=BATCH_STOCK_QUOTES&symbols=MSFT,FB,AAPL&apikey=test"
+        url = "https://www.alphavantage.co/query?function=BATCH_STOCK_QUOTES&symbols=MSFT,FB,AAPL&apikey=test"
         path_file = self.get_file_from_url("mock_batch_quotes")
         with open(path_file) as f:
             mock_request.get(url, text=f.read())
@@ -207,7 +207,7 @@ class TestAlphaVantage(unittest.TestCase):
         """
         ts = TimeSeries(key=TestAlphaVantage._API_KEY_TEST,
                         output_format='pandas')
-        url = "http://www.alphavantage.co/query?function=BATCH_STOCK_QUOTES&symbols=MSFT,FB,AAPL&apikey=test&datatype=json"
+        url = "https://www.alphavantage.co/query?function=BATCH_STOCK_QUOTES&symbols=MSFT,FB,AAPL&apikey=test&datatype=json"
         path_file = self.get_file_from_url("mock_batch_quotes")
         with open(path_file) as f:
             mock_request.get(url, text=f.read())


### PR DESCRIPTION
This change switches the `_ALPHA_VANTAGE_API_URL` to https, which avoids a double roundtrip for each request, since the API gateway sends a redirect to https for any request on plain http. Closes #151 