### PR TITLE
Use ==/!= to compare str, bytes, and int literals

### DIFF
--- a/alpha_vantage/alphavantage.py
+++ b/alpha_vantage/alphavantage.py
@@ -50,7 +50,7 @@ class AlphaVantage(object):
                              'https://www.alphavantage.co/support/#api-key')
         self.key = key
         self.output_format = output_format
-        if self.output_format is 'pandas' and not _PANDAS_FOUND:
+        if self.output_format == 'pandas' and not _PANDAS_FOUND:
             raise ValueError("The pandas library was not found, therefore can "
                              "not be used as an output format, please install "
                              "manually")


### PR DESCRIPTION
Identity is not the same thing as equality in Python so use ==/!= to compare str, bytes, and int literals. In Python >= 3.8, these instances will raise SyntaxWarnings so it is best to fix them now. https://docs.python.org/3.8/whatsnew/3.8.html#porting-to-python-3-8

$ python
```
>>> pandas = "panda"
>>> pandas += "s"
>>> pandas == "pandas"
True
>>> pandas is "pandas"
False
```