### PR TITLE
Adding crypto-rating functionality

### DIFF
--- a/alpha_vantage/cryptocurrencies.py
+++ b/alpha_vantage/cryptocurrencies.py
@@ -60,6 +60,22 @@ class CryptoCurrencies(av):
 
     @av._output_format
     @av._call_api_on_func
+    def get_digital_currency_exchange_rate(self, from_currency, to_currency):
+        """ Returns the realtime exchange rate for any pair of digital
+        currency (e.g., BTC) or physical currency (e.g., USD).
+        Keyword Arguments:
+            from_currency: The currency you would like to get the exchange rate
+            for. It can either be a physical currency or digital/crypto currency.
+            For example: from_currency=USD or from_currency=BTC.
+            to_currency: The destination currency for the exchange rate.
+            It can either be a physical currency or digital/crypto currency.
+            For example: to_currency=USD or to_currency=BTC.
+        """
+        _FUNCTION_KEY = 'CURRENCY_EXCHANGE_RATE'
+        return _FUNCTION_KEY, 'Realtime Currency Exchange Rate', None
+
+    @av._output_format
+    @av._call_api_on_func
     def get_digital_crypto_rating(self, symbol):
         """ Returns the Fundamental Crypto Asset Score for a digital currency
         (e.g., BTC), and when it was last updated.

--- a/alpha_vantage/cryptocurrencies.py
+++ b/alpha_vantage/cryptocurrencies.py
@@ -60,17 +60,14 @@ class CryptoCurrencies(av):
 
     @av._output_format
     @av._call_api_on_func
-    def get_digital_currency_exchange_rate(self, symbol, market):
-        """ Returns the current exchange rate for a digital currency
-        (e.g., BTC) traded on a specific market (e.g., CNY/Chinese Yuan),
-        and when it was last updated.
+    def get_digital_crypto_rating(self, symbol):
+        """ Returns the Fundamental Crypto Asset Score for a digital currency
+        (e.g., BTC), and when it was last updated.
 
         Keyword Arguments:
             symbol: The digital/crypto currency of your choice. It can be any
             of the currencies in the digital currency list. For example:
             symbol=BTC.
-            market: The exchange market of your choice. It can be any of the
-            market in the market list. For example: market=CNY.
         """
-        _FUNCTION_KEY = 'CURRENCY_EXCHANGE_RATE'
-        return _FUNCTION_KEY, 'Dictonary (Digital Currency Exchange Rate)', 'Meta Data'
+        _FUNCTION_KEY = 'CRYPTO_RATING'
+        return _FUNCTION_KEY, 'Crypto Rating (FCAS)', None


### PR DESCRIPTION
Adding crypto-rating functionality and removing the get_digital_currency_exchange_rate that would be just a repetition of the CURRENCY_EXCHANGE_RATE one and it doesn't work anyways since it's referencing that function with the wrong arguments. 