### PR TITLE
Refactoring of internal APIs and adding LISTING_STATUS function

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,11 +52,6 @@ You may also get a key from [rapidAPI](https://rapidapi.com/alphavantage/api/alp
 ts = TimeSeries(key='YOUR_API_KEY',rapidapi=True)
 ```
 
-Internally there is a retries counter, that can be used to minimize connection errors (in case that the API is not able to respond in time), the default is set to
-5 but can be increased or decreased whenever needed.
-```python
-ts = TimeSeries(key='YOUR_API_KEY',retries='YOUR_RETRIES')
-```
 The library supports giving its results as json dictionaries (default), pandas dataframe (if installed) or csv, simply pass the parameter output_format='pandas' to change the format of the output for all the API calls in the given class. Please note that some API calls do not support the csv format (namely ```ForeignExchange, SectorPerformances and TechIndicators```) because the API endpoint does not support the format on their calls either.
 
 ```python
@@ -103,6 +98,17 @@ plt.show()
 ```
 Giving us as output:
 ![alt text](images/docs_ts_msft_example.png?raw=True "MSFT minute value plot example")
+
+### Fundamental data
+It is also possible to query fundamental data.
+
+```python
+from alpha_vantage.fundamentaldata import FundamentalData
+
+fd = FundamentalData(key='YOUR_API_KEY', output_format='pandas')
+data, meta_data = fd.get_listing_status()
+print(data)
+```
 
 ### Technical indicators
 The same way we can get pandas to plot technical indicators like Bollinger Bands®

--- a/alpha_vantage/alphavantage.py
+++ b/alpha_vantage/alphavantage.py
@@ -419,6 +419,9 @@ class AlphaVantage(object):
                 if 'time' in data_pandas.columns:
                     data_pandas.index = data_pandas.time
                     data_pandas.drop(columns=['time'], inplace=True)
+                elif 'timestamp' in data_pandas.columns:
+                    data_pandas.index = data_pandas.timestamp
+                    data_pandas.drop(columns=['timestamp'], inplace=True)
                 data_pandas.index = pandas.to_datetime(data_pandas.index)
             
             return data_pandas

--- a/alpha_vantage/alphavantage.py
+++ b/alpha_vantage/alphavantage.py
@@ -385,7 +385,7 @@ class AlphaVantage(object):
                     else:
                         # JSON to CSV conversion through Pandas.
                         # Convert to CSV reader to stay consistent with native CSV API call.
-                        return csv.reader(data_pandas.to_csv().splitlines())
+                        return csv.reader(data_pandas.to_csv().splitlines()), meta_data
             elif 'csv' == api_format:
                 if 'pandas' == output_format or \
                         'json' == output_format:

--- a/alpha_vantage/alphavantage.py
+++ b/alpha_vantage/alphavantage.py
@@ -1,12 +1,14 @@
-import requests
-import os
-from functools import wraps
 import inspect
+import os
 import sys
-import re
+from functools import wraps
+
 # Pandas became an optional dependency, but we still want to track it
+from helpers.baseurlsession import BaseURLSession
+
 try:
     import pandas
+    
     _PANDAS_FOUND = True
 except ImportError:
     _PANDAS_FOUND = False
@@ -14,35 +16,34 @@ import csv
 
 
 class AlphaVantage(object):
-    """ Base class where the decorators and base function for the other
-    classes of this python wrapper will inherit from.
+    """Base class containing the session. Is subclassed by other classes.
     """
-    _ALPHA_VANTAGE_API_URL = "https://www.alphavantage.co/query?"
+    _ALPHA_VANTAGE_API_URL = "https://www.alphavantage.co/query"
     _ALPHA_VANTAGE_MATH_MAP = ['SMA', 'EMA', 'WMA', 'DEMA', 'TEMA', 'TRIMA',
                                'T3', 'KAMA', 'MAMA']
     _ALPHA_VANTAGE_DIGITAL_CURRENCY_LIST = \
         "https://www.alphavantage.co/digital_currency_list/"
-
-    _RAPIDAPI_URL = "https://alpha-vantage.p.rapidapi.com/query?"
-
-    def __init__(self, key=None, output_format='json',
-                 treat_info_as_error=True, indexing_type='date', proxy=None, rapidapi=False):
-        """ Initialize the class
+    
+    _RAPIDAPI_URL = "https://alpha-vantage.p.rapidapi.com/query"
+    
+    def __init__(self, key: str = None, output_format: str = 'json',
+                 treat_info_as_error: bool = True, indexing_type: str = 'date', proxy: dict = None,
+                 rapidapi: bool = False):
+        """Initialize the class.
 
         Keyword Arguments:
-            key:  Alpha Vantage api key
-            retries:  Maximum amount of retries in case of faulty connection or
-                server not able to answer the call.
-            treat_info_as_error: Treat information from the api as errors
-            output_format:  Either 'json', 'pandas' os 'csv'
+            key:  Alpha Vantage API key.
+            treat_info_as_error: Treat information from the API as errors.
+            output_format:  Specifies the output format directed to the user.
+            Either 'json', 'pandas' os 'csv'.
             indexing_type: Either 'date' to use the default date string given
             by the alpha vantage api call or 'integer' if you just want an
             integer indexing on your dataframe. Only valid, when the
-            output_format is 'pandas'
+            output_format is 'pandas'.
             proxy: Dictionary mapping protocol or protocol and hostname to
             the URL of the proxy.
             rapidapi: Boolean describing whether or not the API key is
-            through the RapidAPI platform or not
+            through the RapidAPI platform or not.
         """
         if key is None:
             key = os.getenv('ALPHAVANTAGE_API_KEY')
@@ -51,274 +52,66 @@ class AlphaVantage(object):
                              'either through the key parameter or '
                              'through the environment variable '
                              'ALPHAVANTAGE_API_KEY. Get a free key '
-                             'from the alphavantage website: '
+                             'from the AlphaVantage website: '
                              'https://www.alphavantage.co/support/#api-key')
-        self.headers = {}
+        
+        # Session preparation
+        # Set RapidAPI-specific URL and Headers.
+        self._create_session(rapidapi)
+        
         if rapidapi:
-            self.headers = {
-                'x-rapidapi-host': "alpha-vantage.p.rapidapi.com",
-                'x-rapidapi-key': key
-            }
-        self.rapidapi = rapidapi
-        self.key = key
-        self.output_format = output_format
+            self.session.headers['x-rapidapi-host'] = "alpha-vantage.p.rapidapi.com"
+            self.session.headers['x-rapidapi-key'] = key
+        # Set AlphaVantage-specific URL and Headers.
+        else:
+            self.session.params['apikey'] = key
+        
+        # Add proxy if specified
+        self.session.proxies = proxy or {}
+        
+        # Storage of further arguments
+        self.output_format = output_format.lower()
         if self.output_format == 'pandas' and not _PANDAS_FOUND:
             raise ValueError("The pandas library was not found, therefore can "
                              "not be used as an output format, please install "
                              "manually")
         self.treat_info_as_error = treat_info_as_error
+        
         # Not all the calls accept a data type appended at the end, this
         # variable will be overridden by those functions not needing it.
         self._append_type = True
-        self.indexing_type = indexing_type
-        self.proxy = proxy or {}
-
-    @classmethod
-    def _call_api_on_func(cls, func):
-        """ Decorator for forming the api call with the arguments of the
-        function, it works by taking the arguments given to the function
-        and building the url to call the api on it
-
-        Keyword Arguments:
-            func:  The function to be decorated
-        """
-
-        # Argument Handling
-        if sys.version_info[0] < 3:
-            # Deprecated since version 3.0
-            argspec = inspect.getargspec(func)
+        self.indexing_type = indexing_type.lower()
+    
+    def close(self):
+        """Closes the underlying session."""
+        self.session.close()
+    
+    def _create_session(self, rapidapi: bool):
+        """Creates a session."""
+        if rapidapi:
+            self.session = BaseURLSession(AlphaVantage._RAPIDAPI_URL)
         else:
-            argspec = inspect.getfullargspec(func)
-        try:
-            # Asumme most of the cases have a mixed between args and named
-            # args
-            positional_count = len(argspec.args) - len(argspec.defaults)
-            defaults = dict(
-                zip(argspec.args[positional_count:], argspec.defaults))
-        except TypeError:
-            if argspec.args:
-                # No defaults
-                positional_count = len(argspec.args)
-                defaults = {}
-            elif argspec.defaults:
-                # Only defaults
-                positional_count = 0
-                defaults = argspec.defaults
-        # Actual decorating
-
-        @wraps(func)
-        def _call_wrapper(self, *args, **kwargs):
-            used_kwargs = kwargs.copy()
-            # Get the used positional arguments given to the function
-            used_kwargs.update(zip(argspec.args[positional_count:],
-                                   args[positional_count:]))
-            # Update the dictionary to include the default parameters from the
-            # function
-            used_kwargs.update({k: used_kwargs.get(k, d)
-                                for k, d in defaults.items()})
-            # Form the base url, the original function called must return
-            # the function name defined in the alpha vantage api and the data
-            # key for it and for its meta data.
-            function_name, data_key, meta_data_key = func(
-                self, *args, **kwargs)
-            base_url = AlphaVantage._RAPIDAPI_URL if self.rapidapi else AlphaVantage._ALPHA_VANTAGE_API_URL
-            url = "{}function={}".format(base_url, function_name)
-            for idx, arg_name in enumerate(argspec.args[1:]):
-                try:
-                    arg_value = args[idx]
-                except IndexError:
-                    arg_value = used_kwargs[arg_name]
-                if 'matype' in arg_name and arg_value:
-                    # If the argument name has matype, we gotta map the string
-                    # or the integer
-                    arg_value = self.map_to_matype(arg_value)
-                if arg_value:
-                    # Discard argument in the url formation if it was set to
-                    # None (in other words, this will call the api with its
-                    # internal defined parameter)
-                    if isinstance(arg_value, tuple) or isinstance(arg_value, list):
-                        # If the argument is given as list, then we have to
-                        # format it, you gotta format it nicely
-                        arg_value = ','.join(arg_value)
-                    url = '{}&{}={}'.format(url, arg_name, arg_value)
-            # Allow the output format to be json or csv (supported by
-            # alphavantage api). Pandas is simply json converted.
-            if 'json' in self.output_format.lower() or 'csv' in self.output_format.lower():
-                oformat = self.output_format.lower()
-            elif 'pandas' in self.output_format.lower():
-                oformat = 'json'
-            else:
-                raise ValueError("Output format: {} not recognized, only json,"
-                                 "pandas and csv are supported".format(
-                                     self.output_format.lower()))
-            apikey_parameter = "" if self.rapidapi else "&apikey={}".format(
-                self.key)
-            if self._append_type:
-                url = '{}{}&datatype={}'.format(url, apikey_parameter, oformat)
-            else:
-                url = '{}{}'.format(url, apikey_parameter)
-            return self._handle_api_call(url), data_key, meta_data_key
-        return _call_wrapper
-
-    @classmethod
-    def _output_format_sector(cls, func, override=None):
-        """ Decorator in charge of giving the output its right format, either
-        json or pandas (replacing the % for usable floats, range 0-1.0)
-
-        Keyword Arguments:
-            func: The function to be decorated
-            override: Override the internal format of the call, default None
-        Returns:
-            A decorator for the format sector api call
-        """
-        @wraps(func)
-        def _format_wrapper(self, *args, **kwargs):
-            json_response, data_key, meta_data_key = func(
-                self, *args, **kwargs)
-            if isinstance(data_key, list):
-                # Replace the strings into percentage
-                data = {key: {k: self.percentage_to_float(v)
-                              for k, v in json_response[key].items()} for key in data_key}
-            else:
-                data = json_response[data_key]
-            # TODO: Fix orientation in a better way
-            meta_data = json_response[meta_data_key]
-            # Allow to override the output parameter in the call
-            if override is None:
-                output_format = self.output_format.lower()
-            elif 'json' or 'pandas' in override.lower():
-                output_format = override.lower()
-            # Choose output format
-            if output_format == 'json':
-                return data, meta_data
-            elif output_format == 'pandas':
-                data_pandas = pandas.DataFrame.from_dict(data,
-                                                         orient='columns')
-                # Rename columns to have a nicer name
-                col_names = [re.sub(r'\d+.', '', name).strip(' ')
-                             for name in list(data_pandas)]
-                data_pandas.columns = col_names
-                return data_pandas, meta_data
-            else:
-                raise ValueError('Format: {} is not supported'.format(
-                    self.output_format))
-        return _format_wrapper
-
-    @classmethod
-    def _output_format(cls, func, override=None):
-        """ Decorator in charge of giving the output its right format, either
-        json or pandas
-
-        Keyword Arguments:
-            func:  The function to be decorated
-            override:  Override the internal format of the call, default None
-        """
-        @wraps(func)
-        def _format_wrapper(self, *args, **kwargs):
-            call_response, data_key, meta_data_key = func(
-                self, *args, **kwargs)
-            if 'json' in self.output_format.lower() or 'pandas' \
-                    in self.output_format.lower():
-                if data_key is not None:
-                    data = call_response[data_key]
-                else:
-                    data = call_response
-                
-
-                if meta_data_key is not None:
-                    meta_data = call_response[meta_data_key]
-                else:
-                    meta_data = None
-                # Allow to override the output parameter in the call
-                if override is None:
-                    output_format = self.output_format.lower()
-                elif 'json' or 'pandas' in override.lower():
-                    output_format = override.lower()
-                # Choose output format
-                if output_format == 'json':
-                    if isinstance(data, list):
-                        # If the call returns a list, then we will append them
-                        # in the resulting data frame. If in the future
-                        # alphavantage decides to do more with returning arrays
-                        # this might become buggy. For now will do the trick.
-                        if not data:
-                            data_pandas = pandas.DataFrame()
-                        else:
-                            data_array = []
-                            for val in data:
-                                data_array.append([v for _, v in val.items()])
-                            data_pandas = pandas.DataFrame(data_array, columns=[
-                                k for k, _ in data[0].items()])
-                        return data_pandas, meta_data
-                    else:
-                        return data, meta_data
-                elif output_format == 'pandas':
-                    if isinstance(data, list):
-                        # If the call returns a list, then we will append them
-                        # in the resulting data frame. If in the future
-                        # alphavantage decides to do more with returning arrays
-                        # this might become buggy. For now will do the trick.
-                        if not data:
-                            data_pandas = pandas.DataFrame()
-                        else:
-                            data_array = []
-                            for val in data:
-                                data_array.append([v for _, v in val.items()])
-                            data_pandas = pandas.DataFrame(data_array, columns=[
-                                k for k, _ in data[0].items()])
-                    else:
-                        try:
-                            data_pandas = pandas.DataFrame.from_dict(data,
-                                                                     orient='index',
-                                                                     dtype='float')
-                        # This is for Global quotes or any other new Alpha Vantage
-                        # data that is added.
-                        # It will have to be updated so that we can get exactly
-                        # The dataframes we want moving forward
-                        except ValueError:
-                            data = {data_key: data}
-                            data_pandas = pandas.DataFrame.from_dict(data,
-                                                                     orient='index',
-                                                                     dtype='object')
-                            return data_pandas, meta_data
-
-                    if 'integer' in self.indexing_type:
-                        # Set Date as an actual column so a new numerical index
-                        # will be created, but only when specified by the user.
-                        data_pandas.reset_index(level=0, inplace=True)
-                        data_pandas.index.name = 'index'
-                    else:
-                        data_pandas.index.name = 'date'
-                        # convert to pandas._libs.tslibs.timestamps.Timestamp
-                        data_pandas.index = pandas.to_datetime(
-                            data_pandas.index)
-                    return data_pandas, meta_data
-            elif 'csv' in self.output_format.lower():
-                return call_response, None
-            else:
-                raise ValueError('Format: {} is not supported'.format(
-                    self.output_format))
-        return _format_wrapper
-
+            self.session = BaseURLSession(AlphaVantage._ALPHA_VANTAGE_API_URL)
+    
     def set_proxy(self, proxy=None):
-        """ Set a new proxy configuration
-
+        """Set a new proxy configuration
+    
         Keyword Arguments:
             proxy: Dictionary mapping protocol or protocol and hostname to
             the URL of the proxy.
         """
-        self.proxy = proxy or {}
-
+        self.session.proxies = proxy or {}
+    
     def map_to_matype(self, matype):
-        """ Convert to the alpha vantage math type integer. It returns an
+        """Convert to the AlphaVantage math type integer. It returns an
         integer correspondent to the type of math to apply to a function. It
         raises ValueError if an integer greater than the supported math types
         is given.
-
+    
         Keyword Arguments:
-            matype:  The math type of the alpha vantage api. It accepts
+            matype:  The math type of the AlphaVantage API. It accepts
             integers or a string representing the math type.
-
+    
                 * 0 = Simple Moving Average (SMA),
                 * 1 = Exponential Moving Average (EMA),
                 * 2 = Weighted Moving Average (WMA),
@@ -337,34 +130,303 @@ class AlphaVantage(object):
         except ValueError:
             value = AlphaVantage._ALPHA_VANTAGE_MATH_MAP.index(matype)
         return value
-
-    def _handle_api_call(self, url):
-        """ Handle the return call from the  api and return a data and meta_data
-        object. It raises a ValueError on problems
-
+    
+    def _handle_api_call(self, params, override=None):
+        """Handle the return call from the API. It raises a ValueError on problems.
+        Allows to override the data type that is requested/expected from the API.
+    
         Keyword Arguments:
-            url:  The url of the service
-            data_key:  The key for getting the data from the jso object
-            meta_data_key:  The key for getting the meta data information out
-            of the json object
+            params:  The parameters to the service.
+            override: The datatype to use instead of the class specified one.
         """
-        response = requests.get(url, proxies=self.proxy, headers=self.headers)
-        if 'json' in self.output_format.lower() or 'pandas' in \
-                self.output_format.lower():
-            json_response = response.json()
-            if not json_response:
-                raise ValueError(
-                    'Error getting data from the api, no return was given.')
-            elif "Error Message" in json_response:
-                raise ValueError(json_response["Error Message"])
-            elif "Information" in json_response and self.treat_info_as_error:
-                raise ValueError(json_response["Information"])
-            elif "Note" in json_response and self.treat_info_as_error:
-                raise ValueError(json_response["Note"])
-            return json_response
+        # Override output format
+        output_format = self.output_format
+        if override is not None:
+            output_format = override
+            if 'datatype' in params:
+                # 'pandas' is no datatype that is supported by the AlphaVantage API
+                # to be consistent with other data type arguments this is converted
+                # to 'json'.
+                if 'pandas' == override:
+                    override = 'json'
+                
+                params['datatype'] = override
+        
+        response = self.session.get('', params=params)
+        
+        # Handle response
+        if 'json' == output_format or \
+                'pandas' == output_format:
+            return self._handle_json_response(response.json())
+        elif 'csv' == output_format:
+            return self._handle_csv_response(response.text)
         else:
-            csv_response = csv.reader(response.text.splitlines())
-            if not csv_response:
-                raise ValueError(
-                    'Error getting data from the api, no return was given.')
-            return csv_response
+            raise NotImplementedError(
+                'Handling of data type {} is not yet supported.'.format(output_format))
+    
+    def _handle_json_response(self, json_response):
+        if not json_response:
+            raise ValueError('Error getting data from the API, no return was given.')
+        
+        elif "Error Message" in json_response:
+            raise ValueError(json_response["Error Message"])
+        
+        elif "Information" in json_response and self.treat_info_as_error:
+            raise ValueError(json_response["Information"])
+        
+        elif "Note" in json_response and self.treat_info_as_error:
+            raise ValueError(json_response["Note"])
+        
+        return json_response
+    
+    def _handle_csv_response(self, text_response):
+        csv_response = csv.reader(text_response.splitlines())
+        if not csv_response:
+            raise ValueError('Error getting data from the API, no return was given.')
+        return csv_response
+    
+    class _call_api_on_func(object):
+        """Decorator for forming the API call with the arguments of the
+        function, it works by taking the arguments given to the function
+        and building the url to call the api on it. Allows overriding the
+        requested/expected output format of the API call.
+        """
+        
+        def __init__(self, override: str = None) -> None:
+            """Initializes this decorator with the override argument."""
+            super().__init__()
+            self.override = override
+        
+        def __call__(cls, func):
+            """The decorator logic, is called before decorated functions
+            are executed.
+            
+            Keyword Arguments:
+                func: The function to be decorated
+            """
+            argspec, positional_count, defaults = cls._handle_arguments(func)
+            
+            # Actual decorating
+            @wraps(func)
+            def _call_wrapper(self, *args, **kwargs):
+                used_kwargs = cls._process_kwargs(args, kwargs, argspec, positional_count, defaults)
+                
+                # Form the base url, the original function called must return
+                # the function name defined in the AlphaVantage API and the data
+                # key for it and for its meta data.
+                function_name, data_key, meta_data_key = func(self, *args, **kwargs)
+                
+                params = cls._create_parameters(self, function_name, argspec, args, used_kwargs)
+                
+                return self._handle_api_call(params, cls.override), data_key, meta_data_key
+            
+            return _call_wrapper
+        
+        def _create_parameters(cls, self, function_name, argspec, args, used_kwargs):
+            # Create parameter dict
+            params = {
+                'function': function_name
+            }
+            
+            for idx, arg_name in enumerate(argspec.args[1:]):
+                try:
+                    arg_value = args[idx]
+                except IndexError:
+                    arg_value = used_kwargs[arg_name]
+                
+                if 'matype' in arg_name and arg_value:
+                    # If the argument name has matype, we gotta map the string
+                    # or the integer
+                    arg_value = self.map_to_matype(arg_value)
+                if arg_value:
+                    # Discard argument in the url formation if it was set to
+                    # None (in other words, this will call the api with its
+                    # internal defined parameter)
+                    if isinstance(arg_value, tuple) or isinstance(arg_value, list):
+                        # If the argument is given as list, then we have to
+                        # format it, you gotta format it nicely
+                        arg_value = ','.join(arg_value)
+                    
+                    params[arg_name] = arg_value
+            
+            # Allow the output format to be JSON or CSV (supported by the
+            # AlphaVantage API). Pandas is simply converted JSON.
+            if 'json' == self.output_format.lower() or \
+                    'csv' == self.output_format.lower():
+                oformat = self.output_format.lower()
+            elif 'pandas' == self.output_format.lower():
+                oformat = 'json'
+            else:
+                raise ValueError("Output format: {} not recognized, only 'json',"
+                                 "'pandas' and 'csv' are supported".format(
+                    self.output_format.lower()))
+            
+            if self._append_type:
+                params['datatype'] = oformat if cls.override is None else cls.override
+            
+            return params
+        
+        def _handle_arguments(self, func):
+            # Argument Handling
+            if sys.version_info[0] < 3:
+                # Deprecated since version 3.0
+                argspec = inspect.getargspec(func)
+            else:
+                argspec = inspect.getfullargspec(func)
+            
+            try:
+                # Assume most of the cases have a mixed between args and named
+                # args
+                positional_count = len(argspec.args) - len(argspec.defaults)
+                defaults = dict(
+                    zip(argspec.args[positional_count:], argspec.defaults))
+            except TypeError:
+                if argspec.args:
+                    # No defaults
+                    positional_count = len(argspec.args)
+                    defaults = {}
+                elif argspec.defaults:
+                    # Only defaults
+                    positional_count = 0
+                    defaults = argspec.defaults
+            
+            return argspec, positional_count, defaults
+        
+        def _process_kwargs(self, args, kwargs, argspec, positional_count, defaults):
+            used_kwargs = kwargs.copy()
+            
+            # Get the used positional arguments given to the function
+            used_kwargs.update(zip(argspec.args[positional_count:],
+                                   args[positional_count:]))
+            
+            # Update the dictionary to include the default parameters from the
+            # function
+            used_kwargs.update({k: used_kwargs.get(k, d)
+                                for k, d in defaults.items()})
+            
+            return used_kwargs
+    
+    class _output_format(object):
+        """Decorator that processes the response output to conform to the
+        requested data type. The data type can also be overridden.
+    
+        Keyword Arguments:
+            override:  Override the output format. Either 'json', 'pandas' or 'csv'.
+        """
+        
+        def __init__(self, override: str = None, formatting: str = 'default') -> None:
+            super().__init__()
+            self.override = override
+            self.formatting = formatting
+        
+        def __call__(cls, func):
+            @wraps(func)
+            def _format_wrapper(self, *args, **kwargs):
+                call_response, data_key, meta_data_key = func(self, *args, **kwargs)
+                
+                return cls._handle_call_response(self, call_response, data_key, meta_data_key)
+            
+            return _format_wrapper
+        
+        def _handle_call_response(cls, self, call_response, data_key, meta_data_key):
+            """Handles the call response of the wrapped function in __call__."""
+            api_format = 'csv' if isinstance(call_response, type(csv.reader(''))) else 'json'
+            
+            # Override of the output format
+            if cls.override is None:
+                output_format = self.output_format.lower()
+            else:
+                output_format = cls.override.lower()
+            
+            if 'json' == api_format:
+                # Formatting for sector performance
+                if 'sector' == cls.formatting:
+                    if isinstance(data_key, list):
+                        data = {key: {k: cls._percentage_to_float(v) for k, v in
+                                      call_response[key].items()} for key in data_key}
+                
+                elif 'default' == cls.formatting:
+                    if data_key is not None:
+                        data = call_response[data_key]
+                    else:
+                        data = call_response
+                
+                if meta_data_key is not None:
+                    meta_data = call_response[meta_data_key]
+                else:
+                    meta_data = None
+                
+                if 'json' == output_format:
+                    return data, meta_data
+                elif 'pandas' == output_format or \
+                        'csv' == output_format:
+                    if isinstance(data, list):
+                        data_pandas = pandas.DataFrame(data)
+                    else:
+                        try:
+                            data_pandas = pandas.DataFrame.from_dict(data,
+                                                                     orient='index',
+                                                                     dtype='float')
+                        # This is for Global quotes or any other new Alpha Vantage
+                        # data that is added.
+                        # It will have to be updated so that we can get exactly
+                        # The dataframes we want moving forward
+                        except ValueError:
+                            data = {data_key: data}
+                            data_pandas = pandas.DataFrame.from_dict(data,
+                                                                     orient='index',
+                                                                     dtype='object')
+                            return data_pandas, meta_data
+                    
+                    data_pandas = cls._convert_pandas_index(self, data_pandas)
+                    
+                    if 'pandas' == output_format:
+                        return data_pandas, meta_data
+                    else:
+                        # JSON to CSV conversion through Pandas.
+                        # Convert to CSV reader to stay consistent with native CSV API call.
+                        return csv.reader(data_pandas.to_csv().splitlines())
+            elif 'csv' == api_format:
+                if 'pandas' == output_format or \
+                        'json' == output_format:
+                    # Converts the CSV reader to a format that can be read by pandas
+                    # directly
+                    data_list = list(call_response)
+                    data_pandas = pandas.DataFrame.from_records(data_list[1:],
+                                                                columns=data_list[0])
+                    
+                    data_pandas = cls._convert_pandas_index(self, data_pandas)
+                    
+                    if 'pandas' == output_format:
+                        return data_pandas, None
+                    else:
+                        return data_pandas.to_json(), None
+                else:
+                    return call_response, None
+        
+        def _convert_pandas_index(self, av, data_pandas: pandas.DataFrame):
+            """Converts the index of a pandas.DataFrame as specified in the AlphaVantage class."""
+            if not isinstance(data_pandas.index, pandas.RangeIndex) and \
+                    'integer' == av.indexing_type and 'default' == self.formatting:
+                # Set Date/Time as an actual column so a new numerical index
+                # will be created, but only when specified by the user.
+                data_pandas.reset_index(level=0, inplace=True)
+                data_pandas.rename(columns={'index': 'date'}, inplace=True)
+                data_pandas.index.name = 'index'
+            elif not isinstance(data_pandas.index, pandas.DatetimeIndex) and \
+                    'date' == av.indexing_type and 'default' == self.formatting:
+                # TODO check if index is actually a date(time) and only convert if this is the case
+                if 'time' in data_pandas.columns:
+                    data_pandas.index = data_pandas.time
+                    data_pandas.drop(columns=['time'], inplace=True)
+                data_pandas.index = pandas.to_datetime(data_pandas.index)
+            
+            return data_pandas
+        
+        def _percentage_to_float(self, val):
+            """Transform a string of the form f.f% into f.f/100
+    
+            Keyword Arguments:
+                val: The string to convert
+            """
+            return float(val.strip('%')) / 100

--- a/alpha_vantage/alphavantage.py
+++ b/alpha_vantage/alphavantage.py
@@ -185,7 +185,7 @@ class AlphaVantage(object):
             raise ValueError('Error getting data from the API, no return was given.')
         return csv_response
     
-    class _call_api_on_func(object):
+    class call_api_on_func(object):
         """Decorator for forming the API call with the arguments of the
         function, it works by taking the arguments given to the function
         and building the url to call the api on it. Allows overriding the
@@ -306,7 +306,7 @@ class AlphaVantage(object):
             
             return used_kwargs
     
-    class _output_format(object):
+    class output_format(object):
         """Decorator that processes the response output to conform to the
         requested data type. The data type can also be overridden.
     

--- a/alpha_vantage/async_support/alphavantage.py
+++ b/alpha_vantage/async_support/alphavantage.py
@@ -1,272 +1,112 @@
-import aiohttp
 from functools import wraps
-import inspect
-import re
+
 # Pandas became an optional dependency, but we still want to track it
+from helpers.asyncbaseurlsession import AsyncBaseURLSession
+from ..alphavantage import AlphaVantage as AlphaVantageBase
+
 try:
     import pandas
+    
     _PANDAS_FOUND = True
 except ImportError:
     _PANDAS_FOUND = False
-import csv
-from ..alphavantage import AlphaVantage as AlphaVantageBase
 
 
 class AlphaVantage(AlphaVantageBase):
-    """
-    Async version of the base class where the decorators and base function for
+    """Async version of the base class where the decorators and base function for
     the other classes of this python wrapper will inherit from.
     """
-
-    def __init__(self, *args, proxy=None, **kwargs):
-        super(AlphaVantage, self).__init__(*args, **kwargs)
-        self.session = None
-        self.proxy = proxy or ''
-
-    @classmethod
-    def _call_api_on_func(cls, func):
-        """ Decorator for forming the api call with the arguments of the
-        function, it works by taking the arguments given to the function
-        and building the url to call the api on it
-
-        Keyword Arguments:
-            func:  The function to be decorated
-        """
-
-        # Argument Handling
-        argspec = inspect.getfullargspec(func)
-        try:
-            # Asumme most of the cases have a mixed between args and named
-            # args
-            positional_count = len(argspec.args) - len(argspec.defaults)
-            defaults = dict(
-                zip(argspec.args[positional_count:], argspec.defaults))
-        except TypeError:
-            if argspec.args:
-                # No defaults
-                positional_count = len(argspec.args)
-                defaults = {}
-            elif argspec.defaults:
-                # Only defaults
-                positional_count = 0
-                defaults = argspec.defaults
-        # Actual decorating
-
-        @wraps(func)
-        async def _call_wrapper(self, *args, **kwargs):
-            used_kwargs = kwargs.copy()
-            # Get the used positional arguments given to the function
-            used_kwargs.update(zip(argspec.args[positional_count:],
-                                   args[positional_count:]))
-            # Update the dictionary to include the default parameters from the
-            # function
-            used_kwargs.update({k: used_kwargs.get(k, d)
-                                for k, d in defaults.items()})
-            # Form the base url, the original function called must return
-            # the function name defined in the alpha vantage api and the data
-            # key for it and for its meta data.
-            function_name, data_key, meta_data_key = func(
-                self, *args, **kwargs)
-            base_url = AlphaVantage._RAPIDAPI_URL if self.rapidapi else AlphaVantage._ALPHA_VANTAGE_API_URL
-            url = "{}function={}".format(base_url, function_name)
-            for idx, arg_name in enumerate(argspec.args[1:]):
-                try:
-                    arg_value = args[idx]
-                except IndexError:
-                    arg_value = used_kwargs[arg_name]
-                if 'matype' in arg_name and arg_value:
-                    # If the argument name has matype, we gotta map the string
-                    # or the integer
-                    arg_value = self.map_to_matype(arg_value)
-                if arg_value:
-                    # Discard argument in the url formation if it was set to
-                    # None (in other words, this will call the api with its
-                    # internal defined parameter)
-                    if isinstance(arg_value, tuple) or isinstance(arg_value, list):
-                        # If the argument is given as list, then we have to
-                        # format it, you gotta format it nicely
-                        arg_value = ','.join(arg_value)
-                    url = '{}&{}={}'.format(url, arg_name, arg_value)
-            # Allow the output format to be json or csv (supported by
-            # alphavantage api). Pandas is simply json converted.
-            if 'json' in self.output_format.lower() or 'csv' in self.output_format.lower():
-                oformat = self.output_format.lower()
-            elif 'pandas' in self.output_format.lower():
-                oformat = 'json'
-            else:
-                raise ValueError("Output format: {} not recognized, only json,"
-                                 "pandas and csv are supported".format(
-                                     self.output_format.lower()))
-            apikey_parameter = "" if self.rapidapi else "&apikey={}".format(
-                self.key)
-            if self._append_type:
-                url = '{}{}&datatype={}'.format(url, apikey_parameter, oformat)
-            else:
-                url = '{}{}'.format(url, apikey_parameter)
-            return await self._handle_api_call(url), data_key, meta_data_key
-        return _call_wrapper
-
-    @classmethod
-    def _output_format_sector(cls, func, override=None):
-        """ Decorator in charge of giving the output its right format, either
-        json or pandas (replacing the % for usable floats, range 0-1.0)
-
-        Keyword Arguments:
-            func: The function to be decorated
-            override: Override the internal format of the call, default None
-        Returns:
-            A decorator for the format sector api call
-        """
-        @wraps(func)
-        async def _format_wrapper(self, *args, **kwargs):
-            json_response, data_key, meta_data_key = await func(
-                self, *args, **kwargs)
-            if isinstance(data_key, list):
-                # Replace the strings into percentage
-                data = {key: {k: self.percentage_to_float(v)
-                              for k, v in json_response[key].items()} for key in data_key}
-            else:
-                data = json_response[data_key]
-            # TODO: Fix orientation in a better way
-            meta_data = json_response[meta_data_key]
-            # Allow to override the output parameter in the call
-            if override is None:
-                output_format = self.output_format.lower()
-            elif 'json' or 'pandas' in override.lower():
-                output_format = override.lower()
-            # Choose output format
-            if output_format == 'json':
-                return data, meta_data
-            elif output_format == 'pandas':
-                data_pandas = pandas.DataFrame.from_dict(data,
-                                                         orient='columns')
-                # Rename columns to have a nicer name
-                col_names = [re.sub(r'\d+.', '', name).strip(' ')
-                             for name in list(data_pandas)]
-                data_pandas.columns = col_names
-                return data_pandas, meta_data
-            else:
-                raise ValueError('Format: {} is not supported'.format(
-                    self.output_format))
-        return _format_wrapper
-
-    @classmethod
-    def _output_format(cls, func, override=None):
-        """ Decorator in charge of giving the output its right format, either
-        json or pandas
-
-        Keyword Arguments:
-            func:  The function to be decorated
-            override:  Override the internal format of the call, default None
-        """
-        @wraps(func)
-        async def _format_wrapper(self, *args, **kwargs):
-            call_response, data_key, meta_data_key = await func(
-                self, *args, **kwargs)
-            if 'json' in self.output_format.lower() or 'pandas' \
-                    in self.output_format.lower():
-                data = call_response[data_key]
-
-                if meta_data_key is not None:
-                    meta_data = call_response[meta_data_key]
-                else:
-                    meta_data = None
-                # Allow to override the output parameter in the call
-                if override is None:
-                    output_format = self.output_format.lower()
-                elif 'json' or 'pandas' in override.lower():
-                    output_format = override.lower()
-                # Choose output format
-                if output_format == 'json':
-                    return data, meta_data
-                elif output_format == 'pandas':
-                    if isinstance(data, list):
-                        # If the call returns a list, then we will append them
-                        # in the resulting data frame. If in the future
-                        # alphavantage decides to do more with returning arrays
-                        # this might become buggy. For now will do the trick.
-                        data_array = []
-                        for val in data:
-                            data_array.append([v for _, v in val.items()])
-                        data_pandas = pandas.DataFrame(data_array, columns=[
-                            k for k, _ in data[0].items()])
-                    else:
-                        try:
-                            data_pandas = pandas.DataFrame.from_dict(data,
-                                                                     orient='index',
-                                                                     dtype='float')
-                        # This is for Global quotes or any other new Alpha Vantage
-                        # data that is added.
-                        # It will have to be updated so that we can get exactly
-                        # The dataframes we want moving forward
-                        except ValueError:
-                            data = {data_key: data}
-                            data_pandas = pandas.DataFrame.from_dict(data,
-                                                                     orient='index',
-                                                                     dtype='object')
-                            return data_pandas, meta_data
-
-                    if 'integer' in self.indexing_type:
-                        # Set Date as an actual column so a new numerical index
-                        # will be created, but only when specified by the user.
-                        data_pandas.reset_index(level=0, inplace=True)
-                        data_pandas.index.name = 'index'
-                    else:
-                        data_pandas.index.name = 'date'
-                        # convert to pandas._libs.tslibs.timestamps.Timestamp
-                        data_pandas.index = pandas.to_datetime(
-                            data_pandas.index)
-                    return data_pandas, meta_data
-            elif 'csv' in self.output_format.lower():
-                return call_response, None
-            else:
-                raise ValueError('Format: {} is not supported'.format(
-                    self.output_format))
-        return _format_wrapper
-
-    def set_proxy(self, proxy=None):
-        """
-        Set a new proxy configuration
-
-        Keyword Arguments:
-            proxy: String URL of the proxy.
-        """
-        self.proxy = proxy or ''
-
-    async def _handle_api_call(self, url):
-        """
-        Handle the return call from the  api and return a data and meta_data
-        object. It raises a ValueError on problems
-
-        Keyword Arguments:
-            url:  The url of the service
-        """
-        if not self.session:
-            self.session = aiohttp.ClientSession()
-        response = await self.session.get(url, proxy=self.proxy, headers=self.headers)
-        if 'json' in self.output_format.lower() or 'pandas' in \
-                self.output_format.lower():
-            json_response = await response.json()
-            if not json_response:
-                raise ValueError(
-                    'Error getting data from the api, no return was given.')
-            elif "Error Message" in json_response:
-                raise ValueError(json_response["Error Message"])
-            elif "Information" in json_response and self.treat_info_as_error:
-                raise ValueError(json_response["Information"])
-            elif "Note" in json_response and self.treat_info_as_error:
-                raise ValueError(json_response["Note"])
-            return json_response
-        else:
-            csv_response = csv.reader(response.text.splitlines())
-            if not csv_response:
-                raise ValueError(
-                    'Error getting data from the api, no return was given.')
-            return csv_response
-
+    
     async def close(self):
-        """
-        Close the underlying aiohttp session
-        """
+        """Close the underlying aiohttp session."""
         if self.session and not self.session.closed:
             await self.session.close()
+    
+    def _create_session(self, rapidapi: bool):
+        """Creates a session."""
+        if rapidapi:
+            self.session = AsyncBaseURLSession(AlphaVantage._RAPIDAPI_URL)
+        else:
+            self.session = AsyncBaseURLSession(AlphaVantage._ALPHA_VANTAGE_API_URL)
+    
+    async def _handle_api_call(self, params, override=None):
+        """Handle the return call from the API. It raises a ValueError on problems.
+        Allows to override the data type that is requested/expected from the API.
+    
+        Keyword Arguments:
+            params:  The parameters to the service.
+            override: The datatype to use instead of the class specified one.
+        """
+        # Override output format
+        output_format = self.output_format
+        if override is not None:
+            output_format = override
+            if 'datatype' in params:
+                # 'pandas' is no datatype that is supported by the AlphaVantage API
+                # to be consistent with other data type arguments this is converted
+                # to 'json'.
+                if 'pandas' == override:
+                    override = 'json'
+                
+                params['datatype'] = override
+        
+        response = await self.session.get('', params=params)
+        
+        # Handle response
+        if 'json' == output_format or \
+                'pandas' == output_format:
+            return self._handle_json_response(await response.json())
+        elif 'csv' == output_format:
+            return self._handle_csv_response(await response.text())
+        else:
+            raise NotImplementedError(
+                'Handling of data type {} is not yet supported.'.format(output_format))
+    
+    class _call_api_on_func(AlphaVantageBase._call_api_on_func):
+        """Decorator for forming the API call with the arguments of the
+        function, it works by taking the arguments given to the function
+        and building the url to call the api on it. Allows overriding the
+        requested/expected output format of the API call.
+        """
+        
+        def __call__(cls, func):
+            """The decorator logic, is called before decorated functions
+            are executed.
+            
+            Keyword Arguments:
+                func: The function to be decorated
+            """
+            argspec, positional_count, defaults = cls._handle_arguments(func)
+            
+            # Actual decorating
+            @wraps(func)
+            async def _call_wrapper(self, *args, **kwargs):
+                used_kwargs = cls._process_kwargs(args, kwargs, argspec, positional_count, defaults)
+                
+                # Form the base url, the original function called must return
+                # the function name defined in the AlphaVantage API and the data
+                # key for it and for its meta data.
+                function_name, data_key, meta_data_key = func(self, *args, **kwargs)
+                
+                params = cls._create_parameters(self, function_name, argspec, args, used_kwargs)
+                
+                return await self._handle_api_call(params, cls.override), data_key, meta_data_key
+            
+            return _call_wrapper
+    
+    class _output_format(AlphaVantageBase._output_format):
+        """Decorator that processes the response output to conform to the
+        requested data type. The data type can also be overridden.
+    
+        Keyword Arguments:
+            override:  Override the output format. Either 'json', 'pandas' or 'csv'.
+        """
+        
+        def __call__(cls, func):
+            @wraps(func)
+            async def _format_wrapper(self, *args, **kwargs):
+                call_response, data_key, meta_data_key = await func(self, *args, **kwargs)
+                
+                return cls._handle_call_response(self, call_response, data_key, meta_data_key)
+            
+            return _format_wrapper

--- a/alpha_vantage/async_support/alphavantage.py
+++ b/alpha_vantage/async_support/alphavantage.py
@@ -62,7 +62,7 @@ class AlphaVantage(AlphaVantageBase):
             raise NotImplementedError(
                 'Handling of data type {} is not yet supported.'.format(output_format))
     
-    class _call_api_on_func(AlphaVantageBase._call_api_on_func):
+    class call_api_on_func(AlphaVantageBase.call_api_on_func):
         """Decorator for forming the API call with the arguments of the
         function, it works by taking the arguments given to the function
         and building the url to call the api on it. Allows overriding the
@@ -94,7 +94,7 @@ class AlphaVantage(AlphaVantageBase):
             
             return _call_wrapper
     
-    class _output_format(AlphaVantageBase._output_format):
+    class output_format(AlphaVantageBase.output_format):
         """Decorator that processes the response output to conform to the
         requested data type. The data type can also be overridden.
     

--- a/alpha_vantage/async_support/fundamentaldata.py
+++ b/alpha_vantage/async_support/fundamentaldata.py
@@ -1,0 +1,1 @@
+../fundamentaldata.py

--- a/alpha_vantage/cryptocurrencies.py
+++ b/alpha_vantage/cryptocurrencies.py
@@ -4,8 +4,8 @@ from .alphavantage import AlphaVantage as av
 class CryptoCurrencies(av):
     """This class implements all the crypto currencies API calls."""
     
-    @av._output_format()
-    @av._call_api_on_func()
+    @av.output_format()
+    @av.call_api_on_func()
     def get_digital_currency_daily(self, symbol, market):
         """ Returns  the daily historical time series for a digital currency
         (e.g., BTC) traded on a specific market (e.g., CNY/Chinese Yuan),
@@ -22,8 +22,8 @@ class CryptoCurrencies(av):
         _FUNCTION_KEY = 'DIGITAL_CURRENCY_DAILY'
         return _FUNCTION_KEY, 'Time Series (Digital Currency Daily)', 'Meta Data'
     
-    @av._output_format()
-    @av._call_api_on_func()
+    @av.output_format()
+    @av.call_api_on_func()
     def get_digital_currency_weekly(self, symbol, market):
         """ Returns  the weekly historical time series for a digital currency
         (e.g., BTC) traded on a specific market (e.g., CNY/Chinese Yuan),
@@ -40,8 +40,8 @@ class CryptoCurrencies(av):
         _FUNCTION_KEY = 'DIGITAL_CURRENCY_WEEKLY'
         return _FUNCTION_KEY, 'Time Series (Digital Currency Weekly)', 'Meta Data'
     
-    @av._output_format()
-    @av._call_api_on_func()
+    @av.output_format()
+    @av.call_api_on_func()
     def get_digital_currency_monthly(self, symbol, market):
         """ Returns  the monthly historical time series for a digital currency
         (e.g., BTC) traded on a specific market (e.g., CNY/Chinese Yuan),
@@ -58,8 +58,8 @@ class CryptoCurrencies(av):
         _FUNCTION_KEY = 'DIGITAL_CURRENCY_MONTHLY'
         return _FUNCTION_KEY, 'Time Series (Digital Currency Monthly)', 'Meta Data'
     
-    @av._output_format()
-    @av._call_api_on_func()
+    @av.output_format()
+    @av.call_api_on_func()
     def get_digital_currency_exchange_rate(self, from_currency, to_currency):
         """ Returns the realtime exchange rate for any pair of digital
         currency (e.g., BTC) or physical currency (e.g., USD).
@@ -74,8 +74,8 @@ class CryptoCurrencies(av):
         _FUNCTION_KEY = 'CURRENCY_EXCHANGE_RATE'
         return _FUNCTION_KEY, 'Realtime Currency Exchange Rate', None
     
-    @av._output_format()
-    @av._call_api_on_func()
+    @av.output_format()
+    @av.call_api_on_func()
     def get_digital_crypto_rating(self, symbol):
         """ Returns the Fundamental Crypto Asset Score for a digital currency
         (e.g., BTC), and when it was last updated.

--- a/alpha_vantage/cryptocurrencies.py
+++ b/alpha_vantage/cryptocurrencies.py
@@ -2,10 +2,10 @@ from .alphavantage import AlphaVantage as av
 
 
 class CryptoCurrencies(av):
-    """This class implements all the crypto currencies api calls
-    """
-    @av._output_format
-    @av._call_api_on_func
+    """This class implements all the crypto currencies API calls."""
+    
+    @av._output_format()
+    @av._call_api_on_func()
     def get_digital_currency_daily(self, symbol, market):
         """ Returns  the daily historical time series for a digital currency
         (e.g., BTC) traded on a specific market (e.g., CNY/Chinese Yuan),
@@ -21,9 +21,9 @@ class CryptoCurrencies(av):
         """
         _FUNCTION_KEY = 'DIGITAL_CURRENCY_DAILY'
         return _FUNCTION_KEY, 'Time Series (Digital Currency Daily)', 'Meta Data'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._call_api_on_func()
     def get_digital_currency_weekly(self, symbol, market):
         """ Returns  the weekly historical time series for a digital currency
         (e.g., BTC) traded on a specific market (e.g., CNY/Chinese Yuan),
@@ -39,9 +39,9 @@ class CryptoCurrencies(av):
         """
         _FUNCTION_KEY = 'DIGITAL_CURRENCY_WEEKLY'
         return _FUNCTION_KEY, 'Time Series (Digital Currency Weekly)', 'Meta Data'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._call_api_on_func()
     def get_digital_currency_monthly(self, symbol, market):
         """ Returns  the monthly historical time series for a digital currency
         (e.g., BTC) traded on a specific market (e.g., CNY/Chinese Yuan),
@@ -57,9 +57,9 @@ class CryptoCurrencies(av):
         """
         _FUNCTION_KEY = 'DIGITAL_CURRENCY_MONTHLY'
         return _FUNCTION_KEY, 'Time Series (Digital Currency Monthly)', 'Meta Data'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._call_api_on_func()
     def get_digital_currency_exchange_rate(self, from_currency, to_currency):
         """ Returns the realtime exchange rate for any pair of digital
         currency (e.g., BTC) or physical currency (e.g., USD).
@@ -73,9 +73,9 @@ class CryptoCurrencies(av):
         """
         _FUNCTION_KEY = 'CURRENCY_EXCHANGE_RATE'
         return _FUNCTION_KEY, 'Realtime Currency Exchange Rate', None
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._call_api_on_func()
     def get_digital_crypto_rating(self, symbol):
         """ Returns the Fundamental Crypto Asset Score for a digital currency
         (e.g., BTC), and when it was last updated.

--- a/alpha_vantage/foreignexchange.py
+++ b/alpha_vantage/foreignexchange.py
@@ -15,8 +15,8 @@ class ForeignExchange(av):
             raise ValueError("Output format {} is not compatible with the ForeignExchange class".format(
                 self.output_format.lower()))
 
-    @av._output_format()
-    @av._call_api_on_func()
+    @av.output_format()
+    @av.call_api_on_func()
     def get_currency_exchange_rate(self, from_currency, to_currency):
         """ Returns the realtime exchange rate for any pair of physical
         currency (e.g., EUR) or physical currency (e.g., USD).
@@ -32,8 +32,8 @@ class ForeignExchange(av):
         _FUNCTION_KEY = 'CURRENCY_EXCHANGE_RATE'
         return _FUNCTION_KEY, 'Realtime Currency Exchange Rate', None
 
-    @av._output_format()
-    @av._call_api_on_func()
+    @av.output_format()
+    @av.call_api_on_func()
     def get_currency_exchange_intraday(self, from_symbol, to_symbol, interval='15min', outputsize='compact'):
         """ Returns the intraday exchange rate for any pair of physical
         currency (e.g., EUR) or physical currency (e.g., USD).
@@ -55,8 +55,8 @@ class ForeignExchange(av):
         _FUNCTION_KEY = 'FX_INTRADAY'
         return _FUNCTION_KEY, "Time Series FX ({})".format(interval), 'Meta Data'
 
-    @av._output_format()
-    @av._call_api_on_func()
+    @av.output_format()
+    @av.call_api_on_func()
     def get_currency_exchange_daily(self, from_symbol, to_symbol, outputsize='compact'):
         """ Returns the daily exchange rate for any pair of physical
         currency (e.g., EUR) or physical currency (e.g., USD).
@@ -75,8 +75,8 @@ class ForeignExchange(av):
         _FUNCTION_KEY = 'FX_DAILY'
         return _FUNCTION_KEY, "Time Series FX (Daily)", 'Meta Data'
 
-    @av._output_format()
-    @av._call_api_on_func()
+    @av.output_format()
+    @av.call_api_on_func()
     def get_currency_exchange_weekly(self, from_symbol, to_symbol, outputsize='compact'):
         """ Returns the weekly exchange rate for any pair of physical
         currency (e.g., EUR) or physical currency (e.g., USD).
@@ -95,8 +95,8 @@ class ForeignExchange(av):
         _FUNCTION_KEY = 'FX_WEEKLY'
         return _FUNCTION_KEY, "Time Series FX (Weekly)", 'Meta Data'
 
-    @av._output_format()
-    @av._call_api_on_func()
+    @av.output_format()
+    @av.call_api_on_func()
     def get_currency_exchange_monthly(self, from_symbol, to_symbol, outputsize='compact'):
         """ Returns the monthly exchange rate for any pair of physical
         currency (e.g., EUR) or physical currency (e.g., USD).

--- a/alpha_vantage/foreignexchange.py
+++ b/alpha_vantage/foreignexchange.py
@@ -15,8 +15,8 @@ class ForeignExchange(av):
             raise ValueError("Output format {} is not compatible with the ForeignExchange class".format(
                 self.output_format.lower()))
 
-    @av._output_format
-    @av._call_api_on_func
+    @av._output_format()
+    @av._call_api_on_func()
     def get_currency_exchange_rate(self, from_currency, to_currency):
         """ Returns the realtime exchange rate for any pair of physical
         currency (e.g., EUR) or physical currency (e.g., USD).
@@ -32,8 +32,8 @@ class ForeignExchange(av):
         _FUNCTION_KEY = 'CURRENCY_EXCHANGE_RATE'
         return _FUNCTION_KEY, 'Realtime Currency Exchange Rate', None
 
-    @av._output_format
-    @av._call_api_on_func
+    @av._output_format()
+    @av._call_api_on_func()
     def get_currency_exchange_intraday(self, from_symbol, to_symbol, interval='15min', outputsize='compact'):
         """ Returns the intraday exchange rate for any pair of physical
         currency (e.g., EUR) or physical currency (e.g., USD).
@@ -55,8 +55,8 @@ class ForeignExchange(av):
         _FUNCTION_KEY = 'FX_INTRADAY'
         return _FUNCTION_KEY, "Time Series FX ({})".format(interval), 'Meta Data'
 
-    @av._output_format
-    @av._call_api_on_func
+    @av._output_format()
+    @av._call_api_on_func()
     def get_currency_exchange_daily(self, from_symbol, to_symbol, outputsize='compact'):
         """ Returns the daily exchange rate for any pair of physical
         currency (e.g., EUR) or physical currency (e.g., USD).
@@ -75,8 +75,8 @@ class ForeignExchange(av):
         _FUNCTION_KEY = 'FX_DAILY'
         return _FUNCTION_KEY, "Time Series FX (Daily)", 'Meta Data'
 
-    @av._output_format
-    @av._call_api_on_func
+    @av._output_format()
+    @av._call_api_on_func()
     def get_currency_exchange_weekly(self, from_symbol, to_symbol, outputsize='compact'):
         """ Returns the weekly exchange rate for any pair of physical
         currency (e.g., EUR) or physical currency (e.g., USD).
@@ -95,8 +95,8 @@ class ForeignExchange(av):
         _FUNCTION_KEY = 'FX_WEEKLY'
         return _FUNCTION_KEY, "Time Series FX (Weekly)", 'Meta Data'
 
-    @av._output_format
-    @av._call_api_on_func
+    @av._output_format()
+    @av._call_api_on_func()
     def get_currency_exchange_monthly(self, from_symbol, to_symbol, outputsize='compact'):
         """ Returns the monthly exchange rate for any pair of physical
         currency (e.g., EUR) or physical currency (e.g., USD).
@@ -107,9 +107,6 @@ class ForeignExchange(av):
                 For example: from_symbol=EUR or from_symbol=USD.
             to_symbol: The destination currency for the exchange rate.
                 For example: to_symbol=USD or to_symbol=JPY.
-            interval:  time interval between two conscutive values,
-                supported values are '1min', '5min', '15min', '30min', '60min'
-                (default '15min')
             outputsize:  The size of the call, supported values are
                 'compact' and 'full; the first returns the last 100 points in the
                 data series, and 'full' returns the full-length monthly times

--- a/alpha_vantage/fundamentaldata.py
+++ b/alpha_vantage/fundamentaldata.py
@@ -17,8 +17,8 @@ class FundamentalData(av):
                 "Output format {} is not compatible with the FundamentalData class.".format(
                     self.output_format.lower()))
     
-    @av._output_format()
-    @av._call_api_on_func('csv')
+    @av.output_format()
+    @av.call_api_on_func('csv')
     def get_listing_status(self, date=None, state='active'):
         """
         Returns a list of active or delisted US stocks and ETFs, either as of the latest trading
@@ -29,8 +29,8 @@ class FundamentalData(av):
         _FUNCTION_KEY = 'LISTING_STATUS'
         return _FUNCTION_KEY, None, None
     
-    @av._output_format()
-    @av._call_api_on_func()
+    @av.output_format()
+    @av.call_api_on_func()
     def get_company_overview(self, symbol):
         """Returns the company information, financial ratios,
         and other key metrics for the equity specified. 
@@ -43,8 +43,8 @@ class FundamentalData(av):
         _FUNCTION_KEY = 'OVERVIEW'
         return _FUNCTION_KEY, None, None
     
-    @av._output_format()
-    @av._call_api_on_func()
+    @av.output_format()
+    @av.call_api_on_func()
     def get_income_statement_annual(self, symbol):
         """Returns the annual and quarterly income statements for the company of interest.
         Data is generally refreshed on the same day a company reports its latest 
@@ -56,8 +56,8 @@ class FundamentalData(av):
         _FUNCTION_KEY = 'INCOME_STATEMENT'
         return _FUNCTION_KEY, 'annualReports', 'symbol'
     
-    @av._output_format()
-    @av._call_api_on_func()
+    @av.output_format()
+    @av.call_api_on_func()
     def get_income_statement_quarterly(self, symbol):
         """Returns the annual and quarterly income statements for the company of interest.
         Data is generally refreshed on the same day a company reports its latest 
@@ -69,8 +69,8 @@ class FundamentalData(av):
         _FUNCTION_KEY = 'INCOME_STATEMENT'
         return _FUNCTION_KEY, 'quarterlyReports', 'symbol'
     
-    @av._output_format()
-    @av._call_api_on_func()
+    @av.output_format()
+    @av.call_api_on_func()
     def get_balance_sheet_annual(self, symbol):
         """Returns the annual and quarterly balance sheets for the company of interest.
         Data is generally refreshed on the same day a company reports its latest 
@@ -82,8 +82,8 @@ class FundamentalData(av):
         _FUNCTION_KEY = 'BALANCE_SHEET'
         return _FUNCTION_KEY, 'annualReports', 'symbol'
     
-    @av._output_format()
-    @av._call_api_on_func()
+    @av.output_format()
+    @av.call_api_on_func()
     def get_balance_sheet_quarterly(self, symbol):
         """Returns the annual and quarterly balance sheets for the company of interest.
         Data is generally refreshed on the same day a company reports its latest 
@@ -95,8 +95,8 @@ class FundamentalData(av):
         _FUNCTION_KEY = 'BALANCE_SHEET'
         return _FUNCTION_KEY, 'quarterlyReports', 'symbol'
     
-    @av._output_format()
-    @av._call_api_on_func()
+    @av.output_format()
+    @av.call_api_on_func()
     def get_cash_flow_annual(self, symbol):
         """Returns the annual and quarterly cash flows for the company of interest.
         Data is generally refreshed on the same day a company reports its latest 
@@ -108,8 +108,8 @@ class FundamentalData(av):
         _FUNCTION_KEY = 'CASH_FLOW'
         return _FUNCTION_KEY, 'annualReports', 'symbol'
     
-    @av._output_format()
-    @av._call_api_on_func()
+    @av.output_format()
+    @av.call_api_on_func()
     def get_cash_flow_quarterly(self, symbol):
         """Returns the annual and quarterly cash flows for the company of interest.
         Data is generally refreshed on the same day a company reports its latest 

--- a/alpha_vantage/fundamentaldata.py
+++ b/alpha_vantage/fundamentaldata.py
@@ -1,27 +1,38 @@
+from datetime import datetime
+
 from .alphavantage import AlphaVantage as av
 
-from datetime import datetime
 search_date = datetime.now().date().strftime('%Y-%m-%d')
 
-class FundamentalData(av):
 
-    """This class implements all the api calls to fundamental data
-    """
+class FundamentalData(av):
+    """This class implements all the api calls to fundamental data"""
+    
     def __init__(self, *args, **kwargs):
-        """
-        Inherit AlphaVantage base class with its default arguments.
-        """
+        """Inherit AlphaVantage base class with its default arguments."""
         super(FundamentalData, self).__init__(*args, **kwargs)
         self._append_type = False
         if self.output_format.lower() == 'csv':
-            raise ValueError("Output format {} is not compatible with the FundamentalData class".format(
-                self.output_format.lower()))
-
-    @av._output_format
-    @av._call_api_on_func
-    def get_company_overview(self, symbol):
+            raise ValueError(
+                "Output format {} is not compatible with the FundamentalData class.".format(
+                    self.output_format.lower()))
+    
+    @av._output_format()
+    @av._call_api_on_func('csv')
+    def get_listing_status(self, date=None, state='active'):
         """
-        Returns the company information, financial ratios, 
+        Returns a list of active or delisted US stocks and ETFs, either as of the latest trading
+        day or at a specific time in history. The endpoint is positioned to facilitate equity
+        research on asset lifecycle and survivorship.
+        """
+        
+        _FUNCTION_KEY = 'LISTING_STATUS'
+        return _FUNCTION_KEY, None, None
+    
+    @av._output_format()
+    @av._call_api_on_func()
+    def get_company_overview(self, symbol):
+        """Returns the company information, financial ratios,
         and other key metrics for the equity specified. 
         Data is generally refreshed on the same day a company reports its latest 
         earnings and financials.
@@ -32,11 +43,10 @@ class FundamentalData(av):
         _FUNCTION_KEY = 'OVERVIEW'
         return _FUNCTION_KEY, None, None
     
-    @av._output_format
-    @av._call_api_on_func
+    @av._output_format()
+    @av._call_api_on_func()
     def get_income_statement_annual(self, symbol):
-        """
-        Returns the annual and quarterly income statements for the company of interest. 
+        """Returns the annual and quarterly income statements for the company of interest.
         Data is generally refreshed on the same day a company reports its latest 
         earnings and financials.
 
@@ -45,12 +55,11 @@ class FundamentalData(av):
         """
         _FUNCTION_KEY = 'INCOME_STATEMENT'
         return _FUNCTION_KEY, 'annualReports', 'symbol'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._call_api_on_func()
     def get_income_statement_quarterly(self, symbol):
-        """
-        Returns the annual and quarterly income statements for the company of interest. 
+        """Returns the annual and quarterly income statements for the company of interest.
         Data is generally refreshed on the same day a company reports its latest 
         earnings and financials.
 
@@ -59,12 +68,11 @@ class FundamentalData(av):
         """
         _FUNCTION_KEY = 'INCOME_STATEMENT'
         return _FUNCTION_KEY, 'quarterlyReports', 'symbol'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._call_api_on_func()
     def get_balance_sheet_annual(self, symbol):
-        """
-        Returns the annual and quarterly balance sheets for the company of interest.
+        """Returns the annual and quarterly balance sheets for the company of interest.
         Data is generally refreshed on the same day a company reports its latest 
         earnings and financials.
 
@@ -73,12 +81,11 @@ class FundamentalData(av):
         """
         _FUNCTION_KEY = 'BALANCE_SHEET'
         return _FUNCTION_KEY, 'annualReports', 'symbol'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._call_api_on_func()
     def get_balance_sheet_quarterly(self, symbol):
-        """
-        Returns the annual and quarterly balance sheets for the company of interest.
+        """Returns the annual and quarterly balance sheets for the company of interest.
         Data is generally refreshed on the same day a company reports its latest 
         earnings and financials.
 
@@ -87,12 +94,11 @@ class FundamentalData(av):
         """
         _FUNCTION_KEY = 'BALANCE_SHEET'
         return _FUNCTION_KEY, 'quarterlyReports', 'symbol'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._call_api_on_func()
     def get_cash_flow_annual(self, symbol):
-        """
-        Returns the annual and quarterly cash flows for the company of interest.
+        """Returns the annual and quarterly cash flows for the company of interest.
         Data is generally refreshed on the same day a company reports its latest 
         earnings and financials.
 
@@ -101,12 +107,11 @@ class FundamentalData(av):
         """
         _FUNCTION_KEY = 'CASH_FLOW'
         return _FUNCTION_KEY, 'annualReports', 'symbol'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._call_api_on_func()
     def get_cash_flow_quarterly(self, symbol):
-        """
-        Returns the annual and quarterly cash flows for the company of interest.
+        """Returns the annual and quarterly cash flows for the company of interest.
         Data is generally refreshed on the same day a company reports its latest 
         earnings and financials.
 

--- a/alpha_vantage/sectorperformance.py
+++ b/alpha_vantage/sectorperformance.py
@@ -5,7 +5,7 @@ from .alphavantage import AlphaVantage as av
 class SectorPerformances(av):
     """This class implements all the sector performance api calls
     """
-
+    
     def __init__(self, *args, **kwargs):
         """
         Inherit AlphaVantage base class with its default arguments
@@ -13,19 +13,12 @@ class SectorPerformances(av):
         super(SectorPerformances, self).__init__(*args, **kwargs)
         self._append_type = False
         if self.output_format.lower() == 'csv':
-            raise ValueError("Output format {} is not comatible with the SectorPerformances class".format(
-                self.output_format.lower()))
-
-    def percentage_to_float(self, val):
-        """ Transform a string of the form f.f% into f.f/100
-
-        Keyword Arguments:
-            val: The string to convert
-        """
-        return float(val.strip('%')) / 100
-
-    @av._output_format_sector
-    @av._call_api_on_func
+            raise ValueError(
+                "Output format {} is not compatible with the SectorPerformances class".format(
+                    self.output_format.lower()))
+    
+    @av._output_format(formatting='sector')
+    @av._call_api_on_func()
     def get_sector(self):
         """This API returns the realtime and historical sector performances
         calculated from S&P500 incumbents.

--- a/alpha_vantage/sectorperformance.py
+++ b/alpha_vantage/sectorperformance.py
@@ -17,8 +17,8 @@ class SectorPerformances(av):
                 "Output format {} is not compatible with the SectorPerformances class".format(
                     self.output_format.lower()))
     
-    @av._output_format(formatting='sector')
-    @av._call_api_on_func()
+    @av.output_format(formatting='sector')
+    @av.call_api_on_func()
     def get_sector(self):
         """This API returns the realtime and historical sector performances
         calculated from S&P500 incumbents.

--- a/alpha_vantage/techindicators.py
+++ b/alpha_vantage/techindicators.py
@@ -16,8 +16,8 @@ class TechIndicators(av):
                 "Output format {} is not comatible with the TechIndicators class".format(
                     self.output_format.lower()))
     
-    @av._output_format()
-    @av._call_api_on_func()
+    @av.output_format()
+    @av.call_api_on_func()
     def get_sma(self, symbol, interval='daily', time_period=20, series_type='close'):
         """ Return simple moving average time series in two json objects as data and
         meta_data. It raises ValueError when problems arise
@@ -34,8 +34,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "SMA"
         return _FUNCTION_KEY, 'Technical Analysis: SMA', 'Meta Data'
     
-    @av._output_format()
-    @av._call_api_on_func()
+    @av.output_format()
+    @av.call_api_on_func()
     def get_ema(self, symbol, interval='daily', time_period=20, series_type='close'):
         """ Return exponential moving average time series in two json objects
         as data and meta_data. It raises ValueError when problems arise
@@ -52,8 +52,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "EMA"
         return _FUNCTION_KEY, 'Technical Analysis: EMA', 'Meta Data'
     
-    @av._output_format()
-    @av._output_format()
+    @av.output_format()
+    @av.output_format()
     def get_wma(self, symbol, interval='daily', time_period=20, series_type='close'):
         """ Return weighted moving average time series in two json objects
         as data and meta_data. It raises ValueError when problems arise
@@ -70,8 +70,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "WMA"
         return _FUNCTION_KEY, 'Technical Analysis: WMA', 'Meta Data'
     
-    @av._output_format()
-    @av._output_format()
+    @av.output_format()
+    @av.output_format()
     def get_dema(self, symbol, interval='daily', time_period=20, series_type='close'):
         """ Return double exponential moving average time series in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -88,8 +88,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "DEMA"
         return _FUNCTION_KEY, 'Technical Analysis: DEMA', 'Meta Data'
     
-    @av._output_format()
-    @av._output_format()
+    @av.output_format()
+    @av.output_format()
     def get_tema(self, symbol, interval='daily', time_period=20, series_type='close'):
         """ Return triple exponential moving average time series in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -106,8 +106,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "TEMA"
         return _FUNCTION_KEY, 'Technical Analysis: TEMA', 'Meta Data'
     
-    @av._output_format()
-    @av._output_format()
+    @av.output_format()
+    @av.output_format()
     def get_trima(self, symbol, interval='daily', time_period=20, series_type='close'):
         """ Return triangular moving average time series in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -124,8 +124,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "TRIMA"
         return _FUNCTION_KEY, 'Technical Analysis: TRIMA', 'Meta Data'
     
-    @av._output_format()
-    @av._output_format()
+    @av.output_format()
+    @av.output_format()
     def get_kama(self, symbol, interval='daily', time_period=20, series_type='close'):
         """ Return Kaufman adaptative moving average time series in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -142,8 +142,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "KAMA"
         return _FUNCTION_KEY, 'Technical Analysis: KAMA', 'Meta Data'
     
-    @av._output_format()
-    @av._output_format()
+    @av.output_format()
+    @av.output_format()
     def get_mama(self, symbol, interval='daily', series_type='close',
                  fastlimit=None, slowlimit=None):
         """ Return MESA adaptative moving average time series in two json
@@ -164,8 +164,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "MAMA"
         return _FUNCTION_KEY, 'Technical Analysis: MAMA', 'Meta Data'
     
-    @av._output_format()
-    @av._output_format()
+    @av.output_format()
+    @av.output_format()
     def get_vwap(self, symbol, interval='5min'):
         """ Returns the volume weighted average price (VWAP) for intraday time series.
 
@@ -178,8 +178,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "VWAP"
         return _FUNCTION_KEY, 'Technical Analysis: VWAP', 'Meta Data'
     
-    @av._output_format()
-    @av._output_format()
+    @av.output_format()
+    @av.output_format()
     def get_t3(self, symbol, interval='daily', time_period=20, series_type='close'):
         """ Return triple exponential moving average time series in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -196,8 +196,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "T3"
         return _FUNCTION_KEY, 'Technical Analysis: T3', 'Meta Data'
     
-    @av._output_format()
-    @av._output_format()
+    @av.output_format()
+    @av.output_format()
     def get_macd(self, symbol, interval='daily', series_type='close',
                  fastperiod=None, slowperiod=None, signalperiod=None):
         """ Return the moving average convergence/divergence time series in two
@@ -218,8 +218,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "MACD"
         return _FUNCTION_KEY, 'Technical Analysis: MACD', 'Meta Data'
     
-    @av._output_format()
-    @av._output_format()
+    @av.output_format()
+    @av.output_format()
     def get_macdext(self, symbol, interval='daily', series_type='close',
                     fastperiod=None, slowperiod=None, signalperiod=None, fastmatype=None,
                     slowmatype=None, signalmatype=None):
@@ -263,8 +263,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "MACDEXT"
         return _FUNCTION_KEY, 'Technical Analysis: MACDEXT', 'Meta Data'
     
-    @av._output_format()
-    @av._output_format()
+    @av.output_format()
+    @av.output_format()
     def get_stoch(self, symbol, interval='daily', fastkperiod=None,
                   slowkperiod=None, slowdperiod=None, slowkmatype=None, slowdmatype=None):
         """ Return the stochatic oscillator values in two
@@ -304,8 +304,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "STOCH"
         return _FUNCTION_KEY, 'Technical Analysis: STOCH', 'Meta Data'
     
-    @av._output_format()
-    @av._output_format()
+    @av.output_format()
+    @av.output_format()
     def get_stochf(self, symbol, interval='daily', fastkperiod=None,
                    fastdperiod=None, fastdmatype=None):
         """ Return the stochatic oscillator values in two
@@ -339,8 +339,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "STOCHF"
         return _FUNCTION_KEY, 'Technical Analysis: STOCHF', 'Meta Data'
     
-    @av._output_format()
-    @av._output_format()
+    @av.output_format()
+    @av.output_format()
     def get_rsi(self, symbol, interval='daily', time_period=20, series_type='close'):
         """ Return the relative strength index time series in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -357,8 +357,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "RSI"
         return _FUNCTION_KEY, 'Technical Analysis: RSI', 'Meta Data'
     
-    @av._output_format()
-    @av._output_format()
+    @av.output_format()
+    @av.output_format()
     def get_stochrsi(self, symbol, interval='daily', time_period=20,
                      series_type='close', fastkperiod=None, fastdperiod=None, fastdmatype=None):
         """ Return the stochatic relative strength index in two
@@ -395,8 +395,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "STOCHRSI"
         return _FUNCTION_KEY, 'Technical Analysis: STOCHRSI', 'Meta Data'
     
-    @av._output_format()
-    @av._output_format()
+    @av.output_format()
+    @av.output_format()
     def get_willr(self, symbol, interval='daily', time_period=20):
         """ Return the Williams' %R (WILLR) values in two json objects as data
         and meta_data. It raises ValueError when problems arise
@@ -411,8 +411,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "WILLR"
         return _FUNCTION_KEY, 'Technical Analysis: WILLR', 'Meta Data'
     
-    @av._output_format()
-    @av._output_format()
+    @av.output_format()
+    @av.output_format()
     def get_adx(self, symbol, interval='daily', time_period=20):
         """ Return  the average directional movement index values in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -427,8 +427,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "ADX"
         return _FUNCTION_KEY, 'Technical Analysis: ADX', 'Meta Data'
     
-    @av._output_format()
-    @av._output_format()
+    @av.output_format()
+    @av.output_format()
     def get_adxr(self, symbol, interval='daily', time_period=20):
         """ Return  the average directional movement index  rating in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -443,8 +443,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "ADXR"
         return _FUNCTION_KEY, 'Technical Analysis: ADXR', 'Meta Data'
     
-    @av._output_format()
-    @av._output_format()
+    @av.output_format()
+    @av.output_format()
     def get_apo(self, symbol, interval='daily', series_type='close',
                 fastperiod=None, slowperiod=None, matype=None):
         """ Return the absolute price oscillator values in two
@@ -477,8 +477,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "APO"
         return _FUNCTION_KEY, 'Technical Analysis: APO', 'Meta Data'
     
-    @av._output_format()
-    @av._call_api_on_func
+    @av.output_format()
+    @av.call_api_on_func
     def get_ppo(self, symbol, interval='daily', series_type='close',
                 fastperiod=None, slowperiod=None, matype=None):
         """ Return the percentage price oscillator values in two
@@ -511,8 +511,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "PPO"
         return _FUNCTION_KEY, 'Technical Analysis: PPO', 'Meta Data'
     
-    @av._output_format()
-    @av._call_api_on_func
+    @av.output_format()
+    @av.call_api_on_func
     def get_mom(self, symbol, interval='daily', time_period=20, series_type='close'):
         """ Return the momentum values in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -529,8 +529,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "MOM"
         return _FUNCTION_KEY, 'Technical Analysis: MOM', 'Meta Data'
     
-    @av._output_format
-    @av._call_api_on_func
+    @av.output_format
+    @av.call_api_on_func
     def get_bop(self, symbol, interval='daily', time_period=20):
         """ Return the balance of power values in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -545,8 +545,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "BOP"
         return _FUNCTION_KEY, 'Technical Analysis: BOP', 'Meta Data'
     
-    @av._output_format
-    @av._call_api_on_func
+    @av.output_format
+    @av.call_api_on_func
     def get_cci(self, symbol, interval='daily', time_period=20):
         """ Return the commodity channel index values  in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -561,8 +561,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "CCI"
         return _FUNCTION_KEY, 'Technical Analysis: CCI', 'Meta Data'
     
-    @av._output_format
-    @av._call_api_on_func
+    @av.output_format
+    @av.call_api_on_func
     def get_cmo(self, symbol, interval='daily', time_period=20, series_type='close'):
         """ Return the Chande momentum oscillator in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -579,8 +579,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "CMO"
         return _FUNCTION_KEY, 'Technical Analysis: CMO', 'Meta Data'
     
-    @av._output_format
-    @av._call_api_on_func
+    @av.output_format
+    @av.call_api_on_func
     def get_roc(self, symbol, interval='daily', time_period=20, series_type='close'):
         """ Return the rate of change values in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -597,8 +597,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "ROC"
         return _FUNCTION_KEY, 'Technical Analysis: ROC', 'Meta Data'
     
-    @av._output_format
-    @av._call_api_on_func
+    @av.output_format
+    @av.call_api_on_func
     def get_rocr(self, symbol, interval='daily', time_period=20, series_type='close'):
         """ Return the rate of change ratio values in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -615,8 +615,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "ROCR"
         return _FUNCTION_KEY, 'Technical Analysis: ROCR', 'Meta Data'
     
-    @av._output_format
-    @av._call_api_on_func
+    @av.output_format
+    @av.call_api_on_func
     def get_aroon(self, symbol, interval='daily', time_period=20, series_type='close'):
         """ Return the aroon values in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -633,8 +633,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "AROON"
         return _FUNCTION_KEY, 'Technical Analysis: AROON', 'Meta Data'
     
-    @av._output_format
-    @av._call_api_on_func
+    @av.output_format
+    @av.call_api_on_func
     def get_aroonosc(self, symbol, interval='daily', time_period=20, series_type='close'):
         """ Return the aroon oscillator values in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -651,8 +651,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "AROONOSC"
         return _FUNCTION_KEY, 'Technical Analysis: AROONOSC', 'Meta Data'
     
-    @av._output_format
-    @av._call_api_on_func
+    @av.output_format
+    @av.call_api_on_func
     def get_mfi(self, symbol, interval='daily', time_period=20, series_type='close'):
         """ Return the money flow index values in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -669,8 +669,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "MFI"
         return _FUNCTION_KEY, 'Technical Analysis: MFI', 'Meta Data'
     
-    @av._output_format
-    @av._call_api_on_func
+    @av.output_format
+    @av.call_api_on_func
     def get_trix(self, symbol, interval='daily', time_period=20, series_type='close'):
         """ Return the1-day rate of change of a triple smooth exponential
         moving average in two json objects as data and meta_data.
@@ -688,8 +688,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "TRIX"
         return _FUNCTION_KEY, 'Technical Analysis: TRIX', 'Meta Data'
     
-    @av._output_format
-    @av._call_api_on_func
+    @av.output_format
+    @av.call_api_on_func
     def get_ultosc(self, symbol, interval='daily', timeperiod1=None,
                    timeperiod2=None, timeperiod3=None):
         """ Return the ultimate oscillaror values in two json objects as
@@ -710,8 +710,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "ULTOSC"
         return _FUNCTION_KEY, 'Technical Analysis: ULTOSC', 'Meta Data'
     
-    @av._output_format
-    @av._call_api_on_func
+    @av.output_format
+    @av.call_api_on_func
     def get_dx(self, symbol, interval='daily', time_period=20, series_type='close'):
         """ Return the directional movement index values in two json objects as
         data and meta_data. It raises ValueError when problems arise
@@ -728,8 +728,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "DX"
         return _FUNCTION_KEY, 'Technical Analysis: DX', 'Meta Data'
     
-    @av._output_format
-    @av._call_api_on_func
+    @av.output_format
+    @av.call_api_on_func
     def get_minus_di(self, symbol, interval='daily', time_period=20):
         """ Return the minus directional indicator values in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -744,8 +744,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "MINUS_DI"
         return _FUNCTION_KEY, 'Technical Analysis: MINUS_DI', 'Meta Data'
     
-    @av._output_format
-    @av._call_api_on_func
+    @av.output_format
+    @av.call_api_on_func
     def get_plus_di(self, symbol, interval='daily', time_period=20):
         """ Return the plus directional indicator values in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -760,8 +760,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "PLUS_DI"
         return _FUNCTION_KEY, 'Technical Analysis: PLUS_DI', 'Meta Data'
     
-    @av._output_format
-    @av._call_api_on_func
+    @av.output_format
+    @av.call_api_on_func
     def get_minus_dm(self, symbol, interval='daily', time_period=20):
         """ Return the minus directional movement values in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -775,8 +775,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "MINUS_DM"
         return _FUNCTION_KEY, 'Technical Analysis: MINUS_DM', 'Meta Data'
     
-    @av._output_format
-    @av._call_api_on_func
+    @av.output_format
+    @av.call_api_on_func
     def get_plus_dm(self, symbol, interval='daily', time_period=20):
         """ Return the plus directional movement values in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -790,8 +790,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "PLUS_DM"
         return _FUNCTION_KEY, 'Technical Analysis: PLUS_DM', 'Meta Data'
     
-    @av._output_format
-    @av._call_api_on_func
+    @av.output_format
+    @av.call_api_on_func
     def get_bbands(self, symbol, interval='daily', time_period=20, series_type='close',
                    nbdevup=None, nbdevdn=None, matype=None):
         """ Return the bollinger bands values in two
@@ -829,8 +829,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "BBANDS"
         return _FUNCTION_KEY, 'Technical Analysis: BBANDS', 'Meta Data'
     
-    @av._output_format
-    @av._call_api_on_func
+    @av.output_format
+    @av.call_api_on_func
     def get_midpoint(self, symbol, interval='daily', time_period=20, series_type='close'):
         """ Return the midpoint values in two json objects as
         data and meta_data. It raises ValueError when problems arise
@@ -847,8 +847,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "MIDPOINT"
         return _FUNCTION_KEY, 'Technical Analysis: MIDPOINT', 'Meta Data'
     
-    @av._output_format
-    @av._call_api_on_func
+    @av.output_format
+    @av.call_api_on_func
     def get_midprice(self, symbol, interval='daily', time_period=20):
         """ Return the midprice values in two json objects as
         data and meta_data. It raises ValueError when problems arise
@@ -863,8 +863,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "MIDPRICE"
         return _FUNCTION_KEY, 'Technical Analysis: MIDPRICE', 'Meta Data'
     
-    @av._output_format
-    @av._call_api_on_func
+    @av.output_format
+    @av.call_api_on_func
     def get_sar(self, symbol, interval='daily', acceleration=None, maximum=None):
         """ Return the midprice values in two json objects as
         data and meta_data. It raises ValueError when problems arise
@@ -882,8 +882,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "SAR"
         return _FUNCTION_KEY, 'Technical Analysis: SAR', 'Meta Data'
     
-    @av._output_format
-    @av._call_api_on_func
+    @av.output_format
+    @av.call_api_on_func
     def get_trange(self, symbol, interval='daily'):
         """ Return the true range values in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -897,8 +897,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "TRANGE"
         return _FUNCTION_KEY, 'Technical Analysis: TRANGE', 'Meta Data'
     
-    @av._output_format
-    @av._call_api_on_func
+    @av.output_format
+    @av.call_api_on_func
     def get_atr(self, symbol, interval='daily', time_period=20):
         """ Return the average true range values in two json objects as
         data and meta_data. It raises ValueError when problems arise
@@ -913,8 +913,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "ATR"
         return _FUNCTION_KEY, 'Technical Analysis: ATR', 'Meta Data'
     
-    @av._output_format
-    @av._call_api_on_func
+    @av.output_format
+    @av.call_api_on_func
     def get_natr(self, symbol, interval='daily', time_period=20):
         """ Return the normalized average true range values in two json objects
         as data and meta_data. It raises ValueError when problems arise
@@ -929,8 +929,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "NATR"
         return _FUNCTION_KEY, 'Technical Analysis: NATR', 'Meta Data'
     
-    @av._output_format
-    @av._call_api_on_func
+    @av.output_format
+    @av.call_api_on_func
     def get_ad(self, symbol, interval='daily'):
         """ Return the Chaikin A/D line values in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -944,8 +944,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "AD"
         return _FUNCTION_KEY, 'Technical Analysis: Chaikin A/D', 'Meta Data'
     
-    @av._output_format
-    @av._call_api_on_func
+    @av.output_format
+    @av.call_api_on_func
     def get_adosc(self, symbol, interval='daily', fastperiod=None,
                   slowperiod=None):
         """ Return the Chaikin A/D oscillator values in two
@@ -963,8 +963,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "ADOSC"
         return _FUNCTION_KEY, 'Technical Analysis: ADOSC', 'Meta Data'
     
-    @av._output_format
-    @av._call_api_on_func
+    @av.output_format
+    @av.call_api_on_func
     def get_obv(self, symbol, interval='daily'):
         """ Return the on balance volume values in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -978,8 +978,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "OBV"
         return _FUNCTION_KEY, 'Technical Analysis: OBV', 'Meta Data'
     
-    @av._output_format
-    @av._call_api_on_func
+    @av.output_format
+    @av.call_api_on_func
     def get_ht_trendline(self, symbol, interval='daily', series_type='close'):
         """ Return the Hilbert transform, instantaneous trendline values in two
         json objects as data and meta_data. It raises ValueError when problems arise
@@ -995,8 +995,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "HT_TRENDLINE"
         return _FUNCTION_KEY, 'Technical Analysis: HT_TRENDLINE', 'Meta Data'
     
-    @av._output_format
-    @av._call_api_on_func
+    @av.output_format
+    @av.call_api_on_func
     def get_ht_sine(self, symbol, interval='daily', series_type='close'):
         """ Return the Hilbert transform, sine wave values in two
         json objects as data and meta_data. It raises ValueError when problems arise
@@ -1012,8 +1012,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "HT_SINE"
         return _FUNCTION_KEY, 'Technical Analysis: HT_SINE', 'Meta Data'
     
-    @av._output_format
-    @av._call_api_on_func
+    @av.output_format
+    @av.call_api_on_func
     def get_ht_trendmode(self, symbol, interval='daily', series_type='close'):
         """ Return the Hilbert transform, trend vs cycle mode in two
         json objects as data and meta_data. It raises ValueError when problems arise
@@ -1029,8 +1029,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "HT_TRENDMODE"
         return _FUNCTION_KEY, 'Technical Analysis: HT_TRENDMODE', 'Meta Data'
     
-    @av._output_format
-    @av._call_api_on_func
+    @av.output_format
+    @av.call_api_on_func
     def get_ht_dcperiod(self, symbol, interval='daily', series_type='close'):
         """ Return the Hilbert transform, dominant cycle period in two
         json objects as data and meta_data. It raises ValueError when problems arise
@@ -1046,8 +1046,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "HT_DCPERIOD"
         return _FUNCTION_KEY, 'Technical Analysis: HT_DCPERIOD', 'Meta Data'
     
-    @av._output_format
-    @av._call_api_on_func
+    @av.output_format
+    @av.call_api_on_func
     def get_ht_dcphase(self, symbol, interval='daily', series_type='close'):
         """ Return the Hilbert transform, dominant cycle phase in two
         json objects as data and meta_data. It raises ValueError when problems arise
@@ -1063,8 +1063,8 @@ class TechIndicators(av):
         _FUNCTION_KEY = "HT_DCPHASE"
         return _FUNCTION_KEY, 'Technical Analysis: HT_DCPHASE', 'Meta Data'
     
-    @av._output_format
-    @av._call_api_on_func
+    @av.output_format
+    @av.call_api_on_func
     def get_ht_phasor(self, symbol, interval='daily', series_type='close'):
         """ Return the Hilbert transform, phasor components in two
         json objects as data and meta_data. It raises ValueError when problems arise

--- a/alpha_vantage/techindicators.py
+++ b/alpha_vantage/techindicators.py
@@ -4,7 +4,7 @@ from .alphavantage import AlphaVantage as av
 class TechIndicators(av):
     """This class implements all the technical indicator api calls
     """
-
+    
     def __init__(self, *args, **kwargs):
         """
         Inherit AlphaVantage base class with its default arguments
@@ -12,11 +12,12 @@ class TechIndicators(av):
         super(TechIndicators, self).__init__(*args, **kwargs)
         self._append_type = False
         if self.output_format.lower() == 'csv':
-            raise ValueError("Output format {} is not comatible with the TechIndicators class".format(
-                self.output_format.lower()))
-
-    @av._output_format
-    @av._call_api_on_func
+            raise ValueError(
+                "Output format {} is not comatible with the TechIndicators class".format(
+                    self.output_format.lower()))
+    
+    @av._output_format()
+    @av._call_api_on_func()
     def get_sma(self, symbol, interval='daily', time_period=20, series_type='close'):
         """ Return simple moving average time series in two json objects as data and
         meta_data. It raises ValueError when problems arise
@@ -32,9 +33,9 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "SMA"
         return _FUNCTION_KEY, 'Technical Analysis: SMA', 'Meta Data'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._call_api_on_func()
     def get_ema(self, symbol, interval='daily', time_period=20, series_type='close'):
         """ Return exponential moving average time series in two json objects
         as data and meta_data. It raises ValueError when problems arise
@@ -50,9 +51,9 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "EMA"
         return _FUNCTION_KEY, 'Technical Analysis: EMA', 'Meta Data'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._output_format()
     def get_wma(self, symbol, interval='daily', time_period=20, series_type='close'):
         """ Return weighted moving average time series in two json objects
         as data and meta_data. It raises ValueError when problems arise
@@ -68,9 +69,9 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "WMA"
         return _FUNCTION_KEY, 'Technical Analysis: WMA', 'Meta Data'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._output_format()
     def get_dema(self, symbol, interval='daily', time_period=20, series_type='close'):
         """ Return double exponential moving average time series in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -86,9 +87,9 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "DEMA"
         return _FUNCTION_KEY, 'Technical Analysis: DEMA', 'Meta Data'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._output_format()
     def get_tema(self, symbol, interval='daily', time_period=20, series_type='close'):
         """ Return triple exponential moving average time series in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -104,9 +105,9 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "TEMA"
         return _FUNCTION_KEY, 'Technical Analysis: TEMA', 'Meta Data'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._output_format()
     def get_trima(self, symbol, interval='daily', time_period=20, series_type='close'):
         """ Return triangular moving average time series in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -122,9 +123,9 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "TRIMA"
         return _FUNCTION_KEY, 'Technical Analysis: TRIMA', 'Meta Data'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._output_format()
     def get_kama(self, symbol, interval='daily', time_period=20, series_type='close'):
         """ Return Kaufman adaptative moving average time series in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -140,9 +141,9 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "KAMA"
         return _FUNCTION_KEY, 'Technical Analysis: KAMA', 'Meta Data'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._output_format()
     def get_mama(self, symbol, interval='daily', series_type='close',
                  fastlimit=None, slowlimit=None):
         """ Return MESA adaptative moving average time series in two json
@@ -162,9 +163,9 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "MAMA"
         return _FUNCTION_KEY, 'Technical Analysis: MAMA', 'Meta Data'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._output_format()
     def get_vwap(self, symbol, interval='5min'):
         """ Returns the volume weighted average price (VWAP) for intraday time series.
 
@@ -176,9 +177,9 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "VWAP"
         return _FUNCTION_KEY, 'Technical Analysis: VWAP', 'Meta Data'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._output_format()
     def get_t3(self, symbol, interval='daily', time_period=20, series_type='close'):
         """ Return triple exponential moving average time series in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -194,9 +195,9 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "T3"
         return _FUNCTION_KEY, 'Technical Analysis: T3', 'Meta Data'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._output_format()
     def get_macd(self, symbol, interval='daily', series_type='close',
                  fastperiod=None, slowperiod=None, signalperiod=None):
         """ Return the moving average convergence/divergence time series in two
@@ -216,9 +217,9 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "MACD"
         return _FUNCTION_KEY, 'Technical Analysis: MACD', 'Meta Data'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._output_format()
     def get_macdext(self, symbol, interval='daily', series_type='close',
                     fastperiod=None, slowperiod=None, signalperiod=None, fastmatype=None,
                     slowmatype=None, signalmatype=None):
@@ -261,9 +262,9 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "MACDEXT"
         return _FUNCTION_KEY, 'Technical Analysis: MACDEXT', 'Meta Data'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._output_format()
     def get_stoch(self, symbol, interval='daily', fastkperiod=None,
                   slowkperiod=None, slowdperiod=None, slowkmatype=None, slowdmatype=None):
         """ Return the stochatic oscillator values in two
@@ -302,9 +303,9 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "STOCH"
         return _FUNCTION_KEY, 'Technical Analysis: STOCH', 'Meta Data'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._output_format()
     def get_stochf(self, symbol, interval='daily', fastkperiod=None,
                    fastdperiod=None, fastdmatype=None):
         """ Return the stochatic oscillator values in two
@@ -337,9 +338,9 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "STOCHF"
         return _FUNCTION_KEY, 'Technical Analysis: STOCHF', 'Meta Data'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._output_format()
     def get_rsi(self, symbol, interval='daily', time_period=20, series_type='close'):
         """ Return the relative strength index time series in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -355,9 +356,9 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "RSI"
         return _FUNCTION_KEY, 'Technical Analysis: RSI', 'Meta Data'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._output_format()
     def get_stochrsi(self, symbol, interval='daily', time_period=20,
                      series_type='close', fastkperiod=None, fastdperiod=None, fastdmatype=None):
         """ Return the stochatic relative strength index in two
@@ -393,9 +394,9 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "STOCHRSI"
         return _FUNCTION_KEY, 'Technical Analysis: STOCHRSI', 'Meta Data'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._output_format()
     def get_willr(self, symbol, interval='daily', time_period=20):
         """ Return the Williams' %R (WILLR) values in two json objects as data
         and meta_data. It raises ValueError when problems arise
@@ -409,9 +410,9 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "WILLR"
         return _FUNCTION_KEY, 'Technical Analysis: WILLR', 'Meta Data'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._output_format()
     def get_adx(self, symbol, interval='daily', time_period=20):
         """ Return  the average directional movement index values in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -425,9 +426,9 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "ADX"
         return _FUNCTION_KEY, 'Technical Analysis: ADX', 'Meta Data'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._output_format()
     def get_adxr(self, symbol, interval='daily', time_period=20):
         """ Return  the average directional movement index  rating in two json
         objects as data and meta_data. It raises ValueError when problems arise
@@ -441,9 +442,9 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "ADXR"
         return _FUNCTION_KEY, 'Technical Analysis: ADXR', 'Meta Data'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._output_format()
     def get_apo(self, symbol, interval='daily', series_type='close',
                 fastperiod=None, slowperiod=None, matype=None):
         """ Return the absolute price oscillator values in two
@@ -475,8 +476,8 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "APO"
         return _FUNCTION_KEY, 'Technical Analysis: APO', 'Meta Data'
-
-    @av._output_format
+    
+    @av._output_format()
     @av._call_api_on_func
     def get_ppo(self, symbol, interval='daily', series_type='close',
                 fastperiod=None, slowperiod=None, matype=None):
@@ -509,8 +510,8 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "PPO"
         return _FUNCTION_KEY, 'Technical Analysis: PPO', 'Meta Data'
-
-    @av._output_format
+    
+    @av._output_format()
     @av._call_api_on_func
     def get_mom(self, symbol, interval='daily', time_period=20, series_type='close'):
         """ Return the momentum values in two json
@@ -527,7 +528,7 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "MOM"
         return _FUNCTION_KEY, 'Technical Analysis: MOM', 'Meta Data'
-
+    
     @av._output_format
     @av._call_api_on_func
     def get_bop(self, symbol, interval='daily', time_period=20):
@@ -543,7 +544,7 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "BOP"
         return _FUNCTION_KEY, 'Technical Analysis: BOP', 'Meta Data'
-
+    
     @av._output_format
     @av._call_api_on_func
     def get_cci(self, symbol, interval='daily', time_period=20):
@@ -559,7 +560,7 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "CCI"
         return _FUNCTION_KEY, 'Technical Analysis: CCI', 'Meta Data'
-
+    
     @av._output_format
     @av._call_api_on_func
     def get_cmo(self, symbol, interval='daily', time_period=20, series_type='close'):
@@ -577,7 +578,7 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "CMO"
         return _FUNCTION_KEY, 'Technical Analysis: CMO', 'Meta Data'
-
+    
     @av._output_format
     @av._call_api_on_func
     def get_roc(self, symbol, interval='daily', time_period=20, series_type='close'):
@@ -595,7 +596,7 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "ROC"
         return _FUNCTION_KEY, 'Technical Analysis: ROC', 'Meta Data'
-
+    
     @av._output_format
     @av._call_api_on_func
     def get_rocr(self, symbol, interval='daily', time_period=20, series_type='close'):
@@ -613,7 +614,7 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "ROCR"
         return _FUNCTION_KEY, 'Technical Analysis: ROCR', 'Meta Data'
-
+    
     @av._output_format
     @av._call_api_on_func
     def get_aroon(self, symbol, interval='daily', time_period=20, series_type='close'):
@@ -631,7 +632,7 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "AROON"
         return _FUNCTION_KEY, 'Technical Analysis: AROON', 'Meta Data'
-
+    
     @av._output_format
     @av._call_api_on_func
     def get_aroonosc(self, symbol, interval='daily', time_period=20, series_type='close'):
@@ -649,7 +650,7 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "AROONOSC"
         return _FUNCTION_KEY, 'Technical Analysis: AROONOSC', 'Meta Data'
-
+    
     @av._output_format
     @av._call_api_on_func
     def get_mfi(self, symbol, interval='daily', time_period=20, series_type='close'):
@@ -667,7 +668,7 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "MFI"
         return _FUNCTION_KEY, 'Technical Analysis: MFI', 'Meta Data'
-
+    
     @av._output_format
     @av._call_api_on_func
     def get_trix(self, symbol, interval='daily', time_period=20, series_type='close'):
@@ -686,7 +687,7 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "TRIX"
         return _FUNCTION_KEY, 'Technical Analysis: TRIX', 'Meta Data'
-
+    
     @av._output_format
     @av._call_api_on_func
     def get_ultosc(self, symbol, interval='daily', timeperiod1=None,
@@ -708,7 +709,7 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "ULTOSC"
         return _FUNCTION_KEY, 'Technical Analysis: ULTOSC', 'Meta Data'
-
+    
     @av._output_format
     @av._call_api_on_func
     def get_dx(self, symbol, interval='daily', time_period=20, series_type='close'):
@@ -726,7 +727,7 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "DX"
         return _FUNCTION_KEY, 'Technical Analysis: DX', 'Meta Data'
-
+    
     @av._output_format
     @av._call_api_on_func
     def get_minus_di(self, symbol, interval='daily', time_period=20):
@@ -742,7 +743,7 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "MINUS_DI"
         return _FUNCTION_KEY, 'Technical Analysis: MINUS_DI', 'Meta Data'
-
+    
     @av._output_format
     @av._call_api_on_func
     def get_plus_di(self, symbol, interval='daily', time_period=20):
@@ -758,7 +759,7 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "PLUS_DI"
         return _FUNCTION_KEY, 'Technical Analysis: PLUS_DI', 'Meta Data'
-
+    
     @av._output_format
     @av._call_api_on_func
     def get_minus_dm(self, symbol, interval='daily', time_period=20):
@@ -773,7 +774,7 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "MINUS_DM"
         return _FUNCTION_KEY, 'Technical Analysis: MINUS_DM', 'Meta Data'
-
+    
     @av._output_format
     @av._call_api_on_func
     def get_plus_dm(self, symbol, interval='daily', time_period=20):
@@ -788,10 +789,10 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "PLUS_DM"
         return _FUNCTION_KEY, 'Technical Analysis: PLUS_DM', 'Meta Data'
-
+    
     @av._output_format
     @av._call_api_on_func
-    def get_bbands(self, symbol, interval='daily', time_period=20,  series_type='close',
+    def get_bbands(self, symbol, interval='daily', time_period=20, series_type='close',
                    nbdevup=None, nbdevdn=None, matype=None):
         """ Return the bollinger bands values in two
         json objects as data and meta_data. It raises ValueError when problems
@@ -827,7 +828,7 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "BBANDS"
         return _FUNCTION_KEY, 'Technical Analysis: BBANDS', 'Meta Data'
-
+    
     @av._output_format
     @av._call_api_on_func
     def get_midpoint(self, symbol, interval='daily', time_period=20, series_type='close'):
@@ -845,7 +846,7 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "MIDPOINT"
         return _FUNCTION_KEY, 'Technical Analysis: MIDPOINT', 'Meta Data'
-
+    
     @av._output_format
     @av._call_api_on_func
     def get_midprice(self, symbol, interval='daily', time_period=20):
@@ -861,7 +862,7 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "MIDPRICE"
         return _FUNCTION_KEY, 'Technical Analysis: MIDPRICE', 'Meta Data'
-
+    
     @av._output_format
     @av._call_api_on_func
     def get_sar(self, symbol, interval='daily', acceleration=None, maximum=None):
@@ -880,7 +881,7 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "SAR"
         return _FUNCTION_KEY, 'Technical Analysis: SAR', 'Meta Data'
-
+    
     @av._output_format
     @av._call_api_on_func
     def get_trange(self, symbol, interval='daily'):
@@ -895,7 +896,7 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "TRANGE"
         return _FUNCTION_KEY, 'Technical Analysis: TRANGE', 'Meta Data'
-
+    
     @av._output_format
     @av._call_api_on_func
     def get_atr(self, symbol, interval='daily', time_period=20):
@@ -911,7 +912,7 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "ATR"
         return _FUNCTION_KEY, 'Technical Analysis: ATR', 'Meta Data'
-
+    
     @av._output_format
     @av._call_api_on_func
     def get_natr(self, symbol, interval='daily', time_period=20):
@@ -927,7 +928,7 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "NATR"
         return _FUNCTION_KEY, 'Technical Analysis: NATR', 'Meta Data'
-
+    
     @av._output_format
     @av._call_api_on_func
     def get_ad(self, symbol, interval='daily'):
@@ -942,7 +943,7 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "AD"
         return _FUNCTION_KEY, 'Technical Analysis: Chaikin A/D', 'Meta Data'
-
+    
     @av._output_format
     @av._call_api_on_func
     def get_adosc(self, symbol, interval='daily', fastperiod=None,
@@ -961,7 +962,7 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "ADOSC"
         return _FUNCTION_KEY, 'Technical Analysis: ADOSC', 'Meta Data'
-
+    
     @av._output_format
     @av._call_api_on_func
     def get_obv(self, symbol, interval='daily'):
@@ -976,7 +977,7 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "OBV"
         return _FUNCTION_KEY, 'Technical Analysis: OBV', 'Meta Data'
-
+    
     @av._output_format
     @av._call_api_on_func
     def get_ht_trendline(self, symbol, interval='daily', series_type='close'):
@@ -993,7 +994,7 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "HT_TRENDLINE"
         return _FUNCTION_KEY, 'Technical Analysis: HT_TRENDLINE', 'Meta Data'
-
+    
     @av._output_format
     @av._call_api_on_func
     def get_ht_sine(self, symbol, interval='daily', series_type='close'):
@@ -1010,7 +1011,7 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "HT_SINE"
         return _FUNCTION_KEY, 'Technical Analysis: HT_SINE', 'Meta Data'
-
+    
     @av._output_format
     @av._call_api_on_func
     def get_ht_trendmode(self, symbol, interval='daily', series_type='close'):
@@ -1027,7 +1028,7 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "HT_TRENDMODE"
         return _FUNCTION_KEY, 'Technical Analysis: HT_TRENDMODE', 'Meta Data'
-
+    
     @av._output_format
     @av._call_api_on_func
     def get_ht_dcperiod(self, symbol, interval='daily', series_type='close'):
@@ -1044,7 +1045,7 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "HT_DCPERIOD"
         return _FUNCTION_KEY, 'Technical Analysis: HT_DCPERIOD', 'Meta Data'
-
+    
     @av._output_format
     @av._call_api_on_func
     def get_ht_dcphase(self, symbol, interval='daily', series_type='close'):
@@ -1061,7 +1062,7 @@ class TechIndicators(av):
         """
         _FUNCTION_KEY = "HT_DCPHASE"
         return _FUNCTION_KEY, 'Technical Analysis: HT_DCPHASE', 'Meta Data'
-
+    
     @av._output_format
     @av._call_api_on_func
     def get_ht_phasor(self, symbol, interval='daily', series_type='close'):

--- a/alpha_vantage/timeseries.py
+++ b/alpha_vantage/timeseries.py
@@ -4,8 +4,8 @@ from .alphavantage import AlphaVantage as av
 class TimeSeries(av):
     """This class implements all the api calls to times series"""
     
-    @av._output_format()
-    @av._call_api_on_func()
+    @av.output_format()
+    @av.call_api_on_func()
     def get_intraday(self, symbol, interval='15min', outputsize='compact'):
         """ Return intraday time series in two json objects as data and
         meta_data. It raises ValueError when problems arise
@@ -23,8 +23,8 @@ class TimeSeries(av):
         _FUNCTION_KEY = "TIME_SERIES_INTRADAY"
         return _FUNCTION_KEY, "Time Series ({})".format(interval), 'Meta Data'
     
-    @av._output_format()
-    @av._call_api_on_func('csv')
+    @av.output_format()
+    @av.call_api_on_func('csv')
     def get_intraday_extended(self, symbol, interval='15min', slice='year1month1', adjusted=True):
         """ Return extended intraday time series in one csv_reader object.
         It raises ValueError when problems arise
@@ -43,8 +43,8 @@ class TimeSeries(av):
         _FUNCTION_KEY = "TIME_SERIES_INTRADAY_EXTENDED"
         return _FUNCTION_KEY, None, None
     
-    @av._output_format()
-    @av._call_api_on_func()
+    @av.output_format()
+    @av.call_api_on_func()
     def get_daily(self, symbol, outputsize='compact'):
         """ Return daily time series in two json objects as data and
         meta_data. It raises ValueError when problems arise
@@ -59,8 +59,8 @@ class TimeSeries(av):
         _FUNCTION_KEY = "TIME_SERIES_DAILY"
         return _FUNCTION_KEY, 'Time Series (Daily)', 'Meta Data'
     
-    @av._output_format()
-    @av._call_api_on_func()
+    @av.output_format()
+    @av.call_api_on_func()
     def get_daily_adjusted(self, symbol, outputsize='compact'):
         """ Return daily adjusted (date, daily open, daily high, daily low,
         daily close, daily split/dividend-adjusted close, daily volume)
@@ -77,8 +77,8 @@ class TimeSeries(av):
         _FUNCTION_KEY = "TIME_SERIES_DAILY_ADJUSTED"
         return _FUNCTION_KEY, 'Time Series (Daily)', 'Meta Data'
     
-    @av._output_format()
-    @av._call_api_on_func()
+    @av.output_format()
+    @av.call_api_on_func()
     def get_weekly(self, symbol):
         """ Return weekly time series in two json objects as data and
         meta_data. It raises ValueError when problems arise
@@ -90,8 +90,8 @@ class TimeSeries(av):
         _FUNCTION_KEY = "TIME_SERIES_WEEKLY"
         return _FUNCTION_KEY, 'Weekly Time Series', 'Meta Data'
     
-    @av._output_format()
-    @av._call_api_on_func()
+    @av.output_format()
+    @av.call_api_on_func()
     def get_weekly_adjusted(self, symbol):
         """  weekly adjusted time series (last trading day of each week,
         weekly open, weekly high, weekly low, weekly close, weekly adjusted
@@ -104,8 +104,8 @@ class TimeSeries(av):
         _FUNCTION_KEY = "TIME_SERIES_WEEKLY_ADJUSTED"
         return _FUNCTION_KEY, 'Weekly Adjusted Time Series', 'Meta Data'
     
-    @av._output_format()
-    @av._call_api_on_func()
+    @av.output_format()
+    @av.call_api_on_func()
     def get_monthly(self, symbol):
         """ Return monthly time series in two json objects as data and
         meta_data. It raises ValueError when problems arise
@@ -117,8 +117,8 @@ class TimeSeries(av):
         _FUNCTION_KEY = "TIME_SERIES_MONTHLY"
         return _FUNCTION_KEY, 'Monthly Time Series', 'Meta Data'
     
-    @av._output_format()
-    @av._call_api_on_func()
+    @av.output_format()
+    @av.call_api_on_func()
     def get_monthly_adjusted(self, symbol):
         """ Return monthly time series in two json objects as data and
         meta_data. It raises ValueError when problems arise
@@ -130,8 +130,8 @@ class TimeSeries(av):
         _FUNCTION_KEY = "TIME_SERIES_MONTHLY_ADJUSTED"
         return _FUNCTION_KEY, 'Monthly Adjusted Time Series', 'Meta Data'
     
-    @av._output_format()
-    @av._call_api_on_func()
+    @av.output_format()
+    @av.call_api_on_func()
     def get_quote_endpoint(self, symbol):
         """ Return the latest price and volume information for a
          security of your choice
@@ -143,8 +143,8 @@ class TimeSeries(av):
         _FUNCTION_KEY = "GLOBAL_QUOTE"
         return _FUNCTION_KEY, 'Global Quote', None
     
-    @av._output_format()
-    @av._call_api_on_func()
+    @av.output_format()
+    @av.call_api_on_func()
     def get_symbol_search(self, keywords):
         """ Return best matching symbols and market information
         based on keywords. It raises ValueError when problems arise

--- a/alpha_vantage/timeseries.py
+++ b/alpha_vantage/timeseries.py
@@ -2,11 +2,10 @@ from .alphavantage import AlphaVantage as av
 
 
 class TimeSeries(av):
-
-    """This class implements all the api calls to times series
-    """
-    @av._output_format
-    @av._call_api_on_func
+    """This class implements all the api calls to times series"""
+    
+    @av._output_format()
+    @av._call_api_on_func()
     def get_intraday(self, symbol, interval='15min', outputsize='compact'):
         """ Return intraday time series in two json objects as data and
         meta_data. It raises ValueError when problems arise
@@ -23,9 +22,9 @@ class TimeSeries(av):
         """
         _FUNCTION_KEY = "TIME_SERIES_INTRADAY"
         return _FUNCTION_KEY, "Time Series ({})".format(interval), 'Meta Data'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._call_api_on_func('csv')
     def get_intraday_extended(self, symbol, interval='15min', slice='year1month1', adjusted=True):
         """ Return extended intraday time series in one csv_reader object.
         It raises ValueError when problems arise
@@ -42,10 +41,10 @@ class TimeSeries(av):
                 Set adjusted=false to query raw (as-traded) intraday values.
         """
         _FUNCTION_KEY = "TIME_SERIES_INTRADAY_EXTENDED"
-        return _FUNCTION_KEY, "Time Series ({})".format(interval), 'Meta Data'
-
-    @av._output_format
-    @av._call_api_on_func
+        return _FUNCTION_KEY, None, None
+    
+    @av._output_format()
+    @av._call_api_on_func()
     def get_daily(self, symbol, outputsize='compact'):
         """ Return daily time series in two json objects as data and
         meta_data. It raises ValueError when problems arise
@@ -59,9 +58,9 @@ class TimeSeries(av):
         """
         _FUNCTION_KEY = "TIME_SERIES_DAILY"
         return _FUNCTION_KEY, 'Time Series (Daily)', 'Meta Data'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._call_api_on_func()
     def get_daily_adjusted(self, symbol, outputsize='compact'):
         """ Return daily adjusted (date, daily open, daily high, daily low,
         daily close, daily split/dividend-adjusted close, daily volume)
@@ -77,9 +76,9 @@ class TimeSeries(av):
         """
         _FUNCTION_KEY = "TIME_SERIES_DAILY_ADJUSTED"
         return _FUNCTION_KEY, 'Time Series (Daily)', 'Meta Data'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._call_api_on_func()
     def get_weekly(self, symbol):
         """ Return weekly time series in two json objects as data and
         meta_data. It raises ValueError when problems arise
@@ -90,9 +89,9 @@ class TimeSeries(av):
         """
         _FUNCTION_KEY = "TIME_SERIES_WEEKLY"
         return _FUNCTION_KEY, 'Weekly Time Series', 'Meta Data'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._call_api_on_func()
     def get_weekly_adjusted(self, symbol):
         """  weekly adjusted time series (last trading day of each week,
         weekly open, weekly high, weekly low, weekly close, weekly adjusted
@@ -104,9 +103,9 @@ class TimeSeries(av):
         """
         _FUNCTION_KEY = "TIME_SERIES_WEEKLY_ADJUSTED"
         return _FUNCTION_KEY, 'Weekly Adjusted Time Series', 'Meta Data'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._call_api_on_func()
     def get_monthly(self, symbol):
         """ Return monthly time series in two json objects as data and
         meta_data. It raises ValueError when problems arise
@@ -117,9 +116,9 @@ class TimeSeries(av):
         """
         _FUNCTION_KEY = "TIME_SERIES_MONTHLY"
         return _FUNCTION_KEY, 'Monthly Time Series', 'Meta Data'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._call_api_on_func()
     def get_monthly_adjusted(self, symbol):
         """ Return monthly time series in two json objects as data and
         meta_data. It raises ValueError when problems arise
@@ -130,9 +129,9 @@ class TimeSeries(av):
         """
         _FUNCTION_KEY = "TIME_SERIES_MONTHLY_ADJUSTED"
         return _FUNCTION_KEY, 'Monthly Adjusted Time Series', 'Meta Data'
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._call_api_on_func()
     def get_quote_endpoint(self, symbol):
         """ Return the latest price and volume information for a
          security of your choice
@@ -143,9 +142,9 @@ class TimeSeries(av):
         """
         _FUNCTION_KEY = "GLOBAL_QUOTE"
         return _FUNCTION_KEY, 'Global Quote', None
-
-    @av._output_format
-    @av._call_api_on_func
+    
+    @av._output_format()
+    @av._call_api_on_func()
     def get_symbol_search(self, keywords):
         """ Return best matching symbols and market information
         based on keywords. It raises ValueError when problems arise

--- a/helpers/asyncbaseurlsession.py
+++ b/helpers/asyncbaseurlsession.py
@@ -1,0 +1,27 @@
+from typing import Optional, Mapping
+from urllib.parse import urljoin
+
+import aiohttp
+from aiohttp import ClientResponse as ClientResponse
+from aiohttp.typedefs import StrOrURL
+
+
+class AsyncBaseURLSession(aiohttp.ClientSession):
+    """Subclassed version of aiohttp.ClientSession supporting a base URL to be used."""
+    
+    def __init__(self, base_url: str, *args, **kwargs) -> None:
+        super().__init__(*args, **kwargs)
+        self.base = base_url
+        self.params = {}
+    
+    async def _request(self, method: str, str_or_url: StrOrURL, *args,
+                       params: Optional[Mapping[str, str]] = None, **kwargs) -> ClientResponse:
+        # Join parameter dictionaries.
+        joined_params = self.params.copy()
+        for key in params:
+            joined_params[key] = str(params[key])
+        
+        # Join base URL with specified URL.
+        url = urljoin(self.base, str_or_url)
+        
+        return await super()._request(method, url, *args, params=joined_params, **kwargs)

--- a/helpers/baseurlsession.py
+++ b/helpers/baseurlsession.py
@@ -1,0 +1,19 @@
+from urllib.parse import urljoin
+
+import requests
+from requests.models import Response
+
+
+class BaseURLSession(requests.Session):
+    """Subclassed version of requests.Session supporting a base URL to be used.
+    
+    Inspired by https://github.com/psf/requests/issues/2554#issuecomment-109341010
+    """
+    
+    def __init__(self, base_url: str) -> None:
+        super().__init__()
+        self.base = base_url
+    
+    def request(self, method, url, *args, **kwargs) -> Response:
+        url = urljoin(self.base, url)
+        return super(BaseURLSession, self).request(method, url, *args, **kwargs)

--- a/test_alpha_vantage/test_alphavantage.py
+++ b/test_alpha_vantage/test_alphavantage.py
@@ -1,18 +1,18 @@
 #! /usr/bin/env python
-from ..alpha_vantage.alphavantage import AlphaVantage
-from ..alpha_vantage.timeseries import TimeSeries
-from ..alpha_vantage.techindicators import TechIndicators
-from ..alpha_vantage.sectorperformance import SectorPerformances
-from ..alpha_vantage.foreignexchange import ForeignExchange
-from ..alpha_vantage.fundamentaldata import FundamentalData
+import collections
+import sys
+import unittest
+from os import path
 
+import requests_mock
 from pandas import DataFrame as df, Timestamp
 
-import unittest
-import sys
-import collections
-from os import path
-import requests_mock
+from ..alpha_vantage.alphavantage import AlphaVantage
+from ..alpha_vantage.foreignexchange import ForeignExchange
+from ..alpha_vantage.fundamentaldata import FundamentalData
+from ..alpha_vantage.sectorperformance import SectorPerformances
+from ..alpha_vantage.techindicators import TechIndicators
+from ..alpha_vantage.timeseries import TimeSeries
 
 
 class TestAlphaVantage(unittest.TestCase):
@@ -49,12 +49,16 @@ class TestAlphaVantage(unittest.TestCase):
         """
         av = AlphaVantage(key=TestAlphaVantage._API_KEY_TEST)
         url = "https://www.alphavantage.co/query?function=TIME_SERIES_INTRADAY&symbol=MSFT&interval=1min&apikey=test"
+        params = {
+            'function': 'TIME_SERIES_INTRADAY',
+            'symbol': 'MSFT',
+            'interval': '1min'
+        }
         path_file = self.get_file_from_url("mock_time_series")
         with open(path_file) as f:
             mock_request.get(url, text=f.read())
-            data = av._handle_api_call(url)
-            self.assertIsInstance(
-                data, dict, 'Result Data must be a dictionary')
+            data = av._handle_api_call(params)
+            self.assertIsInstance(data, dict, 'Result Data must be a dictionary')
 
     @requests_mock.Mocker()
     def test_rapidapi_key(self, mock_request):
@@ -219,15 +223,16 @@ class TestAlphaVantage(unittest.TestCase):
 
     @requests_mock.Mocker()
     def test_fundamental_data(self, mock_request):
-        """Test that api call returns a json file as requested
-        """
+        """Test that api call returns a json file as requested"""
         fd = FundamentalData(key=TestAlphaVantage._API_KEY_TEST)
         url = 'https://www.alphavantage.co/query?function=INCOME_STATEMENT&symbol=IBM&apikey=test'
         path_file = self.get_file_from_url("mock_fundamental_data")
         with open(path_file) as f:
             mock_request.get(url, text=f.read())
             data, _ = fd.get_income_statement_annual(symbol='IBM')
-            self.assertIsInstance(data, df, 'Result Data must be a pandas data frame')
+            self.assertIsInstance(data, list, 'Result Data must be a list of JSONs')
+            for entry in data:
+                self.assertIsInstance(entry, dict, 'Result Data entries must be dicts')
 
     @requests_mock.Mocker()
     def test_company_overview(self, mock_request):

--- a/test_alpha_vantage/test_alphavantage_async.py
+++ b/test_alpha_vantage/test_alphavantage_async.py
@@ -1,18 +1,18 @@
 #!/usr/bin/env python
-from ..alpha_vantage.async_support.alphavantage import AlphaVantage
-from ..alpha_vantage.async_support.timeseries import TimeSeries
-from ..alpha_vantage.async_support.techindicators import TechIndicators
-from ..alpha_vantage.async_support.sectorperformance import SectorPerformances
-from ..alpha_vantage.async_support.foreignexchange import ForeignExchange
+import asyncio
+import json
+import unittest
+from functools import wraps
+from os import path
 
+from aioresponses import aioresponses
 from pandas import DataFrame as df, Timestamp
 
-import asyncio
-from aioresponses import aioresponses
-from functools import wraps
-import json
-from os import path
-import unittest
+from ..alpha_vantage.async_support.alphavantage import AlphaVantage
+from ..alpha_vantage.async_support.foreignexchange import ForeignExchange
+from ..alpha_vantage.async_support.sectorperformance import SectorPerformances
+from ..alpha_vantage.async_support.techindicators import TechIndicators
+from ..alpha_vantage.async_support.timeseries import TimeSeries
 
 
 def make_async(f):
@@ -62,12 +62,16 @@ class TestAlphaVantageAsync(unittest.TestCase):
         """
         av = AlphaVantage(key=TestAlphaVantageAsync._API_KEY_TEST)
         url = "https://www.alphavantage.co/query?function=TIME_SERIES_INTRADAY&symbol=MSFT&interval=1min&apikey=test"
+        params = {
+            'function': 'TIME_SERIES_INTRADAY',
+            'symbol': 'MSFT',
+            'interval': '1min'
+        }
         path_file = self.get_file_from_url("mock_time_series")
         with open(path_file) as f, aioresponses() as m:
             m.get(url, payload=json.loads(f.read()))
-            data = await av._handle_api_call(url)
-            self.assertIsInstance(
-                data, dict, 'Result Data must be a dictionary')
+            data = await av._handle_api_call(params)
+            self.assertIsInstance(data, dict, 'Result Data must be a dictionary')
         await av.close()
 
     @make_async

--- a/test_alpha_vantage/test_integration_alphavantage.py
+++ b/test_alpha_vantage/test_integration_alphavantage.py
@@ -134,8 +134,8 @@ class TestAlphaVantage(unittest.TestCase):
         cc = ForeignExchange(key=TestAlphaVantage._API_KEY_TEST)
         self._assert_result_is_format(cc.get_currency_exchange_rate,
                                       output_format='json',
-                                      from_currency='USD',
-                                      to_currency='EUR')
+                                      from_currency='BTC',
+                                      to_currency='USD')
 
     def test_get_currency_exchange_intraday_json(self):
         """Test that we get a dictionary containing json data

--- a/test_alpha_vantage/test_integration_alphavantage.py
+++ b/test_alpha_vantage/test_integration_alphavantage.py
@@ -1,16 +1,16 @@
 #!/usr/bin/env python
-from ..alpha_vantage.alphavantage import AlphaVantage
-from ..alpha_vantage.timeseries import TimeSeries
-from ..alpha_vantage.techindicators import TechIndicators
-from ..alpha_vantage.cryptocurrencies import CryptoCurrencies
-from ..alpha_vantage.foreignexchange import ForeignExchange
+import os
+import time
+import timeit
+import unittest
 
 from pandas import DataFrame as df
 
-import os
-import unittest
-import timeit
-import time
+from ..alpha_vantage.alphavantage import AlphaVantage
+from ..alpha_vantage.cryptocurrencies import CryptoCurrencies
+from ..alpha_vantage.foreignexchange import ForeignExchange
+from ..alpha_vantage.techindicators import TechIndicators
+from ..alpha_vantage.timeseries import TimeSeries
 
 
 class TestAlphaVantage(unittest.TestCase):
@@ -23,9 +23,9 @@ class TestAlphaVantage(unittest.TestCase):
 
     def setUp(self):
         """
-        Wait some time before running each call again.
+        Wait some time before running each call again, to not exceed 5 per minute.
         """
-        time.sleep(1)
+        time.sleep(12)
 
     def _assert_result_is_format(self, func, output_format='json', **args):
         """Check that the data and meta data object are dictionaries
@@ -135,7 +135,7 @@ class TestAlphaVantage(unittest.TestCase):
         self._assert_result_is_format(cc.get_currency_exchange_rate,
                                       output_format='json',
                                       from_currency='USD',
-                                      to_currency='BTC')
+                                      to_currency='EUR')
 
     def test_get_currency_exchange_intraday_json(self):
         """Test that we get a dictionary containing json data


### PR DESCRIPTION
_This is my first major open source contribution to a project, so please forgive me if there are flaws._

I basically wanted to add support for the `LISTING_STATUS` function of the AlphaVantage API. Due to the fact that the API returns the data of this function as CSV only it was required to override the `output_format` specified at object instantiation.

I tried using the existing decorator, but these were, to my knowledge, unfit to accept arguments. It was therefore required to create decorator classes that are able to accept arguments. As I had no experience with this library I refactored large parts of it while doing so.

Related issues would be: #290, #287, #283, #269, #260

A short overview of what was done:
- Decorator overhaul:
  The function decorators had an `override` parameter, but this could not be set. I could not find a code example of its usage. I figured to set the parameter it was required to create a decorator class. The `_output_format` decorate overrides the `output_format` parameter of the AlphaVantage object.
- Usage of requests.Session:
  There was a lot of string manipulation to create the URL invoking the API. Using the `Session` class this could be reduced.
- Code duplication:
  There was some code duplication between `async_support` and the synchronous code. I tried reducing this as much as possible.

I hope this gives a good overview of the changes. Please don't hesitate to ask any questions.