### PR TITLE
Honor the user's choice on output format

### DIFF
--- a/alpha_vantage/alphavantage.py
+++ b/alpha_vantage/alphavantage.py
@@ -236,22 +236,7 @@ class AlphaVantage(object):
                     output_format = override.lower()
                 # Choose output format
                 if output_format == 'json':
-                    if isinstance(data, list):
-                        # If the call returns a list, then we will append them
-                        # in the resulting data frame. If in the future
-                        # alphavantage decides to do more with returning arrays
-                        # this might become buggy. For now will do the trick.
-                        if not data:
-                            data_pandas = pandas.DataFrame()
-                        else:
-                            data_array = []
-                            for val in data:
-                                data_array.append([v for _, v in val.items()])
-                            data_pandas = pandas.DataFrame(data_array, columns=[
-                                k for k, _ in data[0].items()])
-                        return data_pandas, meta_data
-                    else:
-                        return data, meta_data
+                    return data, meta_data
                 elif output_format == 'pandas':
                     if isinstance(data, list):
                         # If the call returns a list, then we will append them


### PR DESCRIPTION
Fixes an issue where certain endpoints would be processed as `pandas` when in fact the user asked for `json`.
_(This looks like something that resulted from accidental copy-pasting)_