### PR TITLE
📦 new (commodities): can now get historical prices for gold and silver

### DIFF
--- a/alpha_vantage/commodities.py
+++ b/alpha_vantage/commodities.py
@@ -6,6 +6,30 @@ class Commodities(av):
     """
     @av._output_format
     @av._call_api_on_func
+    def get_gold(self, interval='monthly', symbol='GOLD'):
+        """ Returns the Gold historical prices
+
+        Keyword Arguments:
+            interval:  supported values are 'daily', 'weekly', 'monthly' (default 'monthly')
+            symbol: supported values are 'GOLD' and 'XAU' (default 'GOLD')
+        """
+        _FUNCTION_KEY = 'GOLD_SILVER_HISTORY'
+        return _FUNCTION_KEY, 'data', None
+
+    @av._output_format
+    @av._call_api_on_func
+    def get_silver(self, interval='monthly', symbol='SILVER'):
+        """ Returns the Silver historical prices
+
+        Keyword Arguments:
+            interval:  supported values are 'daily', 'weekly', 'monthly' (default 'monthly')
+            symbol: supported values are 'SILVER' and 'XAG' (default 'SILVER')
+        """
+        _FUNCTION_KEY = 'GOLD_SILVER_HISTORY'
+        return _FUNCTION_KEY, 'data', None
+
+    @av._output_format
+    @av._call_api_on_func
     def get_wti(self, interval='monthly'):
         """ Returns the West Texas Intermediate (WTI) crude oil prices.
 


### PR DESCRIPTION
Can now call the API for gold and silver prices

Actual query: https://www.alphavantage.co/query?function=GOLD_SILVER_HISTORY&symbol=SILVER&interval=monthly&apikey=...

Relevant alphavantage API docs: https://www.alphavantage.co/documentation/#gold-silver-history

# Example Usage
```Python
from alpha_vantage.commodities import Commodities

comms = Commodities(...)

data, _ = comms.get_gold()
data, _ = comms.get_silver()
```