### PR TITLE
Add gold and silver commodity endpoints

### DIFF
--- a/alpha_vantage/commodities.py
+++ b/alpha_vantage/commodities.py
@@ -39,6 +39,52 @@ class Commodities(av):
 
     @av._output_format
     @av._call_api_on_func
+    def get_gold(self, interval='monthly', symbol='GOLD'):
+        """ Returns historical prices for gold.
+
+        Keyword Arguments:
+            interval:  supported values are 'daily', 'weekly', 'monthly' (default 'monthly')
+            symbol:  supported values are 'GOLD' and 'XAU' (default 'GOLD')
+        """
+        _FUNCTION_KEY = 'GOLD_SILVER_HISTORY'
+        return _FUNCTION_KEY, 'data', 'nominal'
+
+    @av._output_format
+    @av._call_api_on_func
+    def get_silver(self, interval='monthly', symbol='SILVER'):
+        """ Returns historical prices for silver.
+
+        Keyword Arguments:
+            interval:  supported values are 'daily', 'weekly', 'monthly' (default 'monthly')
+            symbol:  supported values are 'SILVER' and 'XAG' (default 'SILVER')
+        """
+        _FUNCTION_KEY = 'GOLD_SILVER_HISTORY'
+        return _FUNCTION_KEY, 'data', 'nominal'
+
+    @av._output_format
+    @av._call_api_on_func
+    def get_gold_spot(self, symbol='GOLD'):
+        """ Returns the realtime spot price for gold.
+
+        Keyword Arguments:
+            symbol:  supported values are 'GOLD' and 'XAU' (default 'GOLD')
+        """
+        _FUNCTION_KEY = 'GOLD_SILVER_SPOT'
+        return _FUNCTION_KEY, None, None
+
+    @av._output_format
+    @av._call_api_on_func
+    def get_silver_spot(self, symbol='SILVER'):
+        """ Returns the realtime spot price for silver.
+
+        Keyword Arguments:
+            symbol:  supported values are 'SILVER' and 'XAG' (default 'SILVER')
+        """
+        _FUNCTION_KEY = 'GOLD_SILVER_SPOT'
+        return _FUNCTION_KEY, None, None
+
+    @av._output_format
+    @av._call_api_on_func
     def get_copper(self, interval='monthly'):
         """ Returns the global price of copper.
 

--- a/test_alpha_vantage/test_commodities.py
+++ b/test_alpha_vantage/test_commodities.py
@@ -1,0 +1,77 @@
+#! /usr/bin/env python
+import unittest
+
+from pandas import DataFrame as df
+
+import requests_mock
+
+from ..alpha_vantage.commodities import Commodities
+
+
+class TestCommodities(unittest.TestCase):
+
+    _API_KEY_TEST = "test"
+
+    @requests_mock.Mocker()
+    def test_silver_spot(self, mock_request):
+        """Test that silver spot prices are requested correctly"""
+        commodities = Commodities(key=self._API_KEY_TEST)
+        url = "https://www.alphavantage.co/query?function=GOLD_SILVER_SPOT&symbol=SILVER&apikey=test&datatype=json"
+        mock_request.get(url, json={
+            "nominal": "XAGUSD",
+            "timestamp": "2026-06-21 16:52:43",
+            "price": "64.840366422"
+        })
+        data, meta_data = commodities.get_silver_spot()
+        assert isinstance(data, dict)
+        assert data['nominal'] == 'XAGUSD'
+        assert meta_data is None
+
+    @requests_mock.Mocker()
+    def test_gold_spot_with_xau_symbol(self, mock_request):
+        """Test that gold spot prices support XAU as documented"""
+        commodities = Commodities(key=self._API_KEY_TEST)
+        url = "https://www.alphavantage.co/query?function=GOLD_SILVER_SPOT&symbol=XAU&apikey=test&datatype=json"
+        mock_request.get(url, json={
+            "nominal": "XAUUSD",
+            "timestamp": "2026-06-21 16:52:43",
+            "price": "4155.5747450763"
+        })
+        data, meta_data = commodities.get_gold_spot(symbol='XAU')
+        assert isinstance(data, dict)
+        assert data['nominal'] == 'XAUUSD'
+        assert meta_data is None
+
+    @requests_mock.Mocker()
+    def test_silver_history(self, mock_request):
+        """Test that silver history prices are requested correctly"""
+        commodities = Commodities(key=self._API_KEY_TEST)
+        url = "https://www.alphavantage.co/query?function=GOLD_SILVER_HISTORY&interval=daily&symbol=SILVER&apikey=test&datatype=json"
+        mock_request.get(url, json={
+            "nominal": "XAGUSD",
+            "data": [
+                {"date": "2026-06-20", "price": "64.8413998488"},
+                {"date": "2026-06-19", "price": "65.3517075323"}
+            ]
+        })
+        data, meta_data = commodities.get_silver(interval='daily')
+        assert isinstance(data, df)
+        assert list(data.columns) == ['date', 'price']
+        assert meta_data == 'XAGUSD'
+
+    @requests_mock.Mocker()
+    def test_gold_history_with_xau_symbol(self, mock_request):
+        """Test that gold history prices support XAU as documented"""
+        commodities = Commodities(key=self._API_KEY_TEST)
+        url = "https://www.alphavantage.co/query?function=GOLD_SILVER_HISTORY&interval=weekly&symbol=XAU&apikey=test&datatype=json"
+        mock_request.get(url, json={
+            "nominal": "XAUUSD",
+            "data": [
+                {"date": "2026-06-20", "price": "4155.5747450763"},
+                {"date": "2026-06-13", "price": "4101.141"}
+            ]
+        })
+        data, meta_data = commodities.get_gold(interval='weekly', symbol='XAU')
+        assert isinstance(data, df)
+        assert list(data.columns) == ['date', 'price']
+        assert meta_data == 'XAUUSD'


### PR DESCRIPTION
## Summary

Adds wrappers for the official Alpha Vantage gold/silver endpoints in `Commodities`, aligned with the existing commodity method style (`get_wti()`, `get_copper()`, etc.):

Historical series:

- `get_gold(interval="monthly", symbol="GOLD")` -> `GOLD_SILVER_HISTORY`
- `get_silver(interval="monthly", symbol="SILVER")` -> `GOLD_SILVER_HISTORY`

Realtime spot prices:

- `get_gold_spot(symbol="GOLD")` -> `GOLD_SILVER_SPOT`
- `get_silver_spot(symbol="SILVER")` -> `GOLD_SILVER_SPOT`

The official docs accept:

- Gold: `GOLD` / `XAU`
- Silver: `SILVER` / `XAG`

Historical intervals are documented as:

- `daily`
- `weekly`
- `monthly`

## Relationship to #387

This PR overlaps with #387 on the historical endpoint (`GOLD_SILVER_HISTORY`). I updated this PR to follow the same package-style API direction as #387 (`get_gold()` / `get_silver()`), while also adding:

- realtime spot endpoint support (`get_gold_spot()` / `get_silver_spot()`)
- test coverage for history and spot methods
- `XAU` / `XAG` symbol coverage in tests

If maintainers prefer #387 as the base implementation, I am happy to adapt this PR to contribute only the missing spot endpoint support and tests.

## Context

This follows up on the previously closed #385. The duplicate follow-up issue #389 was closed in favor of this implementation PR.

The official API supports these endpoints, but they were not exposed through the Python wrapper. Using `ForeignExchange` / `FX_DAILY` is not a substitute for XAG/USD or XAU/USD, because gold/silver are handled by the dedicated `GOLD_SILVER_*` endpoints.

## Tests

```bash
python -m pytest test_alpha_vantage/test_commodities.py -q
```

Result:

```text
4 passed
```

I also tried a broader existing test file, but it appears blocked by an unrelated existing import problem around `sectorperformance.py` not being present in the branch.
